### PR TITLE
Add backend function for getting url patterns

### DIFF
--- a/casepro/backend/__init__.py
+++ b/casepro/backend/__init__.py
@@ -199,6 +199,15 @@ class BaseBackend(object):
                  Message.as_json() for incoming messages and Outgoing.as_json() for outgoing messages.
         """
 
+    @abstractmethod
+    def get_url_patterns(self):
+        """
+        Returns the list of URL patterns that should be registered for this
+        backend.
+
+        :return: a list of URL patterns.
+        """
+
 
 class NoopBackend(BaseBackend):
     """

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -345,3 +345,7 @@ class RapidProBackend(BaseBackend):
             }
 
         return [remote_as_json(m) for m in remote_messages if m.direction == 'out']
+
+    def get_url_patterns(self):
+        '''The Rapidpro backend doesn't have any urls to register.'''
+        return []

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -842,6 +842,11 @@ class RapidProBackendTest(BaseCasesTest):
         outgoing = self.create_outgoing(self.unicef, self.admin, 201, 'B', "Hello", self.ann)
         self.assertEqual(messages[0].keys(), outgoing.as_json().keys())
 
+    def test_get_url_patterns(self):
+        '''Getting the list of url patterns for the rapidpro backend should
+        return an empty list.'''
+        self.assertEqual(self.backend.get_url_patterns(), [])
+
 
 @skip
 class PerfTest(BaseCasesTest):

--- a/casepro/urls.py
+++ b/casepro/urls.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.conf.urls import include, url
 
+from casepro.backend import get_backend
 from casepro.utils.views import PartialTemplate
+
 
 urlpatterns = [
     url(r'', include('casepro.cases.urls')),
@@ -15,6 +17,9 @@ urlpatterns = [
     url(r'^i18n/', include('django.conf.urls.i18n')),
     url(r'^partials/(?P<template>[a-z0-9\-_]+)\.html$', PartialTemplate.as_view(), name='utils.partial_template')
 ]
+
+backend_urls = get_backend().get_url_patterns() or []
+urlpatterns += backend_urls
 
 if settings.DEBUG:  # pragma: no cover
     import debug_toolbar


### PR DESCRIPTION
For our new backend, we're going to need a way to register URLs, but this should be backend dependant.

The plan is to add a function to the BaseBackend definition that will generate a list of url patterns that should be registered. The current RapidPro backend will implement this function as just returning an empty list.

This function then needs to be called in the correct place to register the URLs.