### PR TITLE
OPENHELPD-14 Creation and Management of Languages

### DIFF
--- a/casepro/msgs/forms.py
+++ b/casepro/msgs/forms.py
@@ -7,7 +7,7 @@ from casepro.contacts.models import Group
 from casepro.rules.forms import FieldTestField
 from casepro.utils import parse_csv, normalize
 
-from .models import Label
+from .models import Label, Language
 
 
 class LabelForm(forms.ModelForm):
@@ -74,3 +74,14 @@ class LabelForm(forms.ModelForm):
     class Meta:
         model = Label
         fields = ('name', 'description', 'keywords', 'groups', 'field_test', 'is_synced')
+
+
+class LanguageForm(forms.ModelForm):
+
+    code = forms.CharField(label=_("6-digit Language Code (e.g. eng_UK)"), max_length=6)
+    name = forms.CharField(label=_("Language Name (e.g. English"), max_length=100)
+    location = forms.CharField(label=_("Language Location (e.g. United Kingdom"), max_length=100)
+
+    class Meta:
+        model = Language
+        fields = ('code', 'name', 'location')

--- a/casepro/msgs/migrations/0048_language.py
+++ b/casepro/msgs/migrations/0048_language.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0016_taskstate_is_disabled'),
+        ('msgs', '0047_outgoing_urn'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Language',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('code', models.CharField(max_length=6)),
+                ('name', models.CharField(max_length=100, null=True, blank=True)),
+                ('location', models.CharField(max_length=100, null=True, blank=True)),
+                ('org', models.ForeignKey(related_name='languages', verbose_name='Organization', to='orgs.Org')),
+            ],
+        ),
+    ]

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -94,6 +94,31 @@ class Label(models.Model):
 
 
 @python_2_unicode_compatible
+class Language(models.Model):
+    """
+    Languages used, defined by the ISO 639-3 language code combined with the location code, e.g. eng_UK
+    """
+    org = models.ForeignKey(Org, verbose_name=_("Organization"), related_name='languages')
+
+    code = models.CharField(max_length=6)  # e.g. eng_UK
+
+    name = models.CharField(max_length=100, null=True, blank=True)  # e.g. English
+
+    location = models.CharField(max_length=100, null=True, blank=True)  # e.g. United Kingdom
+
+    def as_json(self):
+        return {
+            'id': self.pk,
+            'code': self.code,
+            'name': self.name,
+            'location': self.location
+        }
+
+    def __str__(self):
+        return "%s - %s - %s" % (self.code, self.name, self.location)
+
+
+@python_2_unicode_compatible
 class Message(models.Model):
     """
     A incoming message from the backend

--- a/casepro/msgs/urls.py
+++ b/casepro/msgs/urls.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 
-from .views import LabelCRUDL, MessageCRUDL, MessageExportCRUDL, OutgoingCRUDL, ReplyExportCRUDL
+from .views import LabelCRUDL, LanguageCRUDL, MessageCRUDL, MessageExportCRUDL, OutgoingCRUDL, ReplyExportCRUDL
 
 urlpatterns = LabelCRUDL().as_urlpatterns()
+urlpatterns += LanguageCRUDL().as_urlpatterns()
 urlpatterns += MessageCRUDL().as_urlpatterns()
 urlpatterns += MessageExportCRUDL().as_urlpatterns()
 urlpatterns += OutgoingCRUDL().as_urlpatterns()

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -172,10 +172,6 @@ class LanguageCRUDL(SmartCRUDL):
     class Update(OrgPermsMixin, SmartUpdateView):
         form_class = LanguageForm
 
-        # def derive_initial(self):
-        #     initial = super(LanguageCRUDL.Update, self).derive_initial()
-        #     return initial
-
     class Delete(OrgPermsMixin, SmartDeleteView):
         cancel_url = '@msgs.language_list'
 

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -5,20 +5,21 @@ import six
 from collections import defaultdict
 from dash.orgs.views import OrgPermsMixin, OrgObjPermsMixin
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.core.urlresolvers import reverse
 from django.utils.timesince import timesince
 from django.utils.translation import ugettext_lazy as _
 from el_pagination.paginators import LazyPaginator
 from smartmin.mixins import NonAtomicMixin
 from smartmin.views import SmartCRUDL, SmartTemplateView
-from smartmin.views import SmartListView, SmartCreateView, SmartUpdateView, SmartDeleteView
+from smartmin.views import SmartListView, SmartCreateView, SmartUpdateView, SmartDeleteView, SmartReadView
 from temba_client.utils import parse_iso8601
 
 from casepro.rules.models import ContainsTest, GroupsTest, Quantifier
 from casepro.utils import parse_csv, str_to_bool, json_encode, JSONEncoder
 from casepro.utils.export import BaseDownloadView
 
-from .forms import LabelForm
-from .models import Label, Message, MessageExport, MessageFolder, Outgoing, OutgoingFolder, ReplyExport
+from .forms import LabelForm, LanguageForm
+from .models import Label, Language, Message, MessageExport, MessageFolder, Outgoing, OutgoingFolder, ReplyExport
 from .tasks import message_export, reply_export
 
 
@@ -127,6 +128,62 @@ class LabelCRUDL(SmartCRUDL):
 
         def get_partners(self, obj):
             return ', '.join([p.name for p in obj.get_partners()])
+
+
+class LanguageCRUDL(SmartCRUDL):
+    model = Language
+    actions = ('list', 'create', 'read', 'update', 'delete')
+
+    class List(OrgPermsMixin, SmartListView):
+        fields = ('code', 'name', 'location')
+        default_order = ('code',)
+
+    class Create(OrgPermsMixin, SmartCreateView):
+        form_class = LanguageForm
+
+        def get_form_kwargs(self):
+            kwargs = super(LanguageCRUDL.Create, self).get_form_kwargs()
+            return kwargs
+
+        def save(self, obj):
+            data = self.form.cleaned_data
+            org = self.request.org
+            code = data['code']
+            name = data['name']
+            location = data['location']
+
+            self.object = Language.objects.create(org=org, code=code, name=name, location=location)
+
+    class Read(OrgPermsMixin, SmartReadView):
+        fields = ['code', 'name', 'location']
+
+        def get_queryset(self):
+            return Language.objects.all()
+
+        def get_context_data(self, **kwargs):
+            context = super(LanguageCRUDL.Read, self).get_context_data(**kwargs)
+            edit_button_url = reverse('msgs.language_update', args=[self.object.pk])
+            context['context_data_json'] = json_encode({'language': self.object.as_json()})
+            context['edit_button_url'] = edit_button_url
+            context['can_delete'] = True
+
+            return context
+
+    class Update(OrgPermsMixin, SmartUpdateView):
+        form_class = LanguageForm
+
+        # def derive_initial(self):
+        #     initial = super(LanguageCRUDL.Update, self).derive_initial()
+        #     return initial
+
+    class Delete(OrgPermsMixin, SmartDeleteView):
+        cancel_url = '@msgs.language_list'
+
+        def post(self, request, *args, **kwargs):
+            language = self.get_object()
+            language.delete()
+
+            return HttpResponse(status=204)
 
 
 class MessageSearchMixin(object):

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -309,6 +309,8 @@ PERMISSIONS = {
 
     'msgs.label': ('create', 'update', 'list'),
 
+    'msgs.language': ('create', 'read', 'update', 'delete', 'list'),
+
     'msgs.message': ('action', 'bulk_reply', 'forward', 'label', 'history', 'search', 'unlabelled'),
 
     'msgs.messageexport': ('create', 'read'),
@@ -339,6 +341,7 @@ GROUP_PERMISSIONS = {
         'orgs.org_inbox',
 
         'msgs.label.*',
+        'msgs.language.*',
         'msgs.message.*',
         'msgs.messageexport.*',
         'msgs.outgoing.*',

--- a/casepro/test.py
+++ b/casepro/test.py
@@ -5,7 +5,7 @@ import json
 from casepro.backend import NoopBackend
 from casepro.cases.models import Case, Partner
 from casepro.contacts.models import Contact, Group, Field
-from casepro.msgs.models import Label, Message, Outgoing
+from casepro.msgs.models import Label, Language, Message, Outgoing
 from casepro.profiles.models import Profile, ROLE_ANALYST, ROLE_MANAGER
 from casepro.rules.models import ContainsTest, Quantifier
 from casepro.utils import json_encode
@@ -47,6 +47,11 @@ class BaseCasesTest(DashTest):
         self.tea = self.create_label(self.unicef, None, "Tea", 'Messages about tea', ["tea", "chai"], is_synced=False)
         self.code = self.create_label(self.nyaruka, "L-101", "Code", 'Messages about code', ["java", "python", "go"])
 
+        # some languages
+        self.eng_za = self.create_language(self.unicef, "eng_ZA", "English", "South Africa")
+        self.cgg_ug = self.create_language(self.unicef, "cgg_UG", "Rukiga", "Uganda")
+        self.lug_ug = self.create_language(self.unicef, "lug_UG", "Luganda", "Uganda")
+
         # some partners
         self.moh = self.create_partner(self.unicef, "MOH", [self.aids, self.pregnancy])
         self.who = self.create_partner(self.unicef, "WHO", [self.aids])
@@ -84,6 +89,9 @@ class BaseCasesTest(DashTest):
         tests = json_encode([ContainsTest(keywords, Quantifier.ANY)])
         return Label.objects.create(org=org, uuid=uuid, name=name, description=description,
                                     tests=tests, **kwargs)
+
+    def create_language(self, org, code, name, location):
+        return Language.objects.create(org=org, code=code, name=name, location=location)
 
     def create_contact(self, org, uuid, name, groups=(), fields=None, is_stub=False):
         contact = Contact.objects.create(org=org, uuid=uuid, name=name, is_stub=is_stub, fields=fields, language="eng")

--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -75,6 +75,14 @@ def normalize(text):
     return unicodedata.normalize('NFKD', re.sub(r'\s+', ' ', text.lower()))
 
 
+def normalize_language_code(text):
+    """
+    Converts letters 5 & 6 to uppercase.
+    """
+    normalized_code = normalize(text)
+    return normalized_code[0:4] + normalized_code[4:6].upper()
+
+
 def match_keywords(text, keywords):
     """
     Checks the given text for a keyword match

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -607,6 +607,22 @@ controllers.controller('UserController', ['$scope', '$window', 'UtilsService', '
 
 
 #============================================================================
+# Language view controller
+#============================================================================
+controllers.controller('LanguageController', ['$scope', '$window', 'UtilsService', 'LanguageService', ($scope, $window, UtilsService, LanguageService) ->
+
+  $scope.language = $window.contextData.language
+
+  $scope.onDeleteLanguage = () ->
+    UtilsService.confirmModal("Delete this Language?", 'danger').then(() ->
+      LanguageService.delete($scope.language).then(() ->
+        UtilsService.navigateBack()
+      )
+    )
+])
+
+
+#============================================================================
 # Date range controller
 #============================================================================
 controllers.controller('DateRangeController', ['$scope', ($scope) ->

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -374,6 +374,20 @@ services.factory('UserService', ['$http', ($http) ->
 
 
 #=====================================================================
+# Language service
+#=====================================================================
+services.factory('LanguageService', ['$http', ($http) ->
+  new class LanguageService
+
+    #----------------------------------------------------------------------------
+    # Delete the given language
+    #----------------------------------------------------------------------------
+    delete: (language) ->
+      return $http.post('/language/delete/' + language.id + '/')
+])
+
+
+#=====================================================================
 # Utils service
 #=====================================================================
 services.factory('UtilsService', ['$window', '$uibModal', ($window, $uibModal) ->

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -82,7 +82,7 @@
                           - trans "Tasks"
 
               - else
-                - if request.user.is_superuser or org_perms.orgs.org_home or org_perms.msgs.label_list or org_perms.cases.group_list or org_perms.profiles.profile_user_list
+                - if request.user.is_superuser or org_perms.orgs.org_home or org_perms.msgs.label_list or org_perms.msgs.language_list or org_perms.cases.group_list or org_perms.profiles.profile_user_list
                   %li.dropdown
                     %a.dropdown-toggle{href:"#", data-toggle:"dropdown"}
                       - trans "Administration"
@@ -97,6 +97,11 @@
                         %li
                           %a{ href:"{% url 'msgs.label_list' %}" }
                             - trans "Labels"
+
+                      - if perms.msgs.language_list or org_perms.msgs.language_list
+                        %li
+                          %a{ href:"{% url 'msgs.language_list' %}" }
+                            - trans "Languages"
 
                       - if perms.contacts.group_list or org_perms.contacts.group_list
                         %li

--- a/templates/msgs/language_list.haml
+++ b/templates/msgs/language_list.haml
@@ -1,0 +1,9 @@
+- extends "smartmin/list.html"
+- load smartmin i18n
+
+- block table-controls
+  .clearfix
+    .pull-away.buttons
+    %a.btn.btn-default.pull-right{ href:"{% url 'msgs.language_create' %}" }
+      %span.glyphicon.glyphicon-plus
+      - trans "Add"

--- a/templates/msgs/language_read.haml
+++ b/templates/msgs/language_read.haml
@@ -1,0 +1,23 @@
+- extends "smartmin/read.html"
+- load smartmin i18n
+
+- block pre-content
+
+  %script{ type:"text/javascript" }
+    var contextData = {{ context_data_json|safe }};
+
+  .ng-cloak{ ng-controller:"LanguageController", ng-cloak:"" }
+    .page-header.clearfix
+      .page-header-buttons
+        - if edit_button_url
+          .btn-group
+            %a.btn.btn-default{ href:"{{ edit_button_url }}", tooltip:"Edit Language" }
+              %i.glyphicon.glyphicon-pencil
+            - if can_delete
+              %a.btn.btn-default{ ng-click:"onDeleteLanguage()", tooltip:"Delete Language" }
+                %i.glyphicon.glyphicon-trash
+
+      %h2
+        Language Details
+
+- block read-buttons


### PR DESCRIPTION
Add a language model that can be managed in a similar fashion to the FAQ model.  This will be used for translation of FAQs.  Languages should also be created via the batch uploads automatically, but this will be handled in issue #12.