### PR TITLE
Add Identity store lookup for outbound messages

### DIFF
--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -22,7 +22,6 @@ class IdentityStore(object):
     def get_paginated_response(self, url, params={}, **kwargs):
         '''Get the results of all pages of a response.'''
         results = []
-        url = url
         while url is not None:
             r = self.session.get(url, params=params, **kwargs)
             data = r.json()

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -20,16 +20,16 @@ class IdentityStore(object):
         self.session.headers.update({'Content-Type': 'application/json'})
 
     def get_paginated_response(self, url, params={}, **kwargs):
-        '''Get the results of all pages of a response.'''
-        results = []
+        '''Get the results of all pages of a response. Returns an iterator that
+        returns each of the items.'''
         while url is not None:
             r = self.session.get(url, params=params, **kwargs)
             data = r.json()
-            results += data.get('results', [])
+            for result in data.get('results', []):
+                yield result
             url = data.get('next', None)
             # params are included in the next url
             params = {}
-        return results
 
     def get_addresses(self, uuid):
         '''Get the list of addresses for an identity specified by uuid.'''
@@ -37,8 +37,8 @@ class IdentityStore(object):
             '%s/api/v1/identities/%s/addresses/%s' % (
                 self.base_url, uuid, self.address_type),
             params={'default': True})
-        return [
-            a['address'] for a in addresses if a.get('address') is not None]
+        return (
+            a['address'] for a in addresses if a.get('address') is not None)
 
 
 class JunebugMessageSendingError(Exception):

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -65,6 +65,11 @@ JUNEBUG_API_ROOT = 'http://localhost:8080/'
 JUNEBUG_CHANNEL_ID = 'replace-me'
 JUNEBUG_FROM_ADDRESS = None
 
+# identity store configuration
+IDENTITY_API_ROOT = 'http://localhost:8081/'
+IDENTITY_AUTH_TOKEN = 'replace-with-auth-token'
+IDENTITY_ADDRESS_TYPE = 'msisdn'
+
 # On Unix systems, a value of None will cause Django to use the same
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your


### PR DESCRIPTION
We should add an identity store lookup for outbound messages where we have a contact, but no URN, in order to get the contact's address.