### PR TITLE
Get communicate_through addresses if available

### DIFF
--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -44,7 +44,7 @@ class IdentityStore(object):
         by uuid should be sent to.'''
         identity = self.get_identity(uuid)
         if identity and identity.get('communicate_through') is not None:
-            return self.get_addresses(identity['communicate_through'])
+            identity = self.get_identity(identity['communicate_through'])
         addresses = self.get_paginated_response(
             '%s/api/v1/identities/%s/addresses/%s' % (
                 self.base_url, uuid, self.address_type),

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -47,7 +47,7 @@ class IdentityStore(object):
             identity = self.get_identity(identity['communicate_through'])
         addresses = self.get_paginated_response(
             '%s/api/v1/identities/%s/addresses/%s' % (
-                self.base_url, uuid, self.address_type),
+                self.base_url, identity['id'], self.address_type),
             params={'default': True})
         return (
             a['address'] for a in addresses if a.get('address') is not None)

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -31,8 +31,20 @@ class IdentityStore(object):
             # params are included in the next url
             params = {}
 
+    def get_identity(self, uuid):
+        '''Returns the details of the identity.'''
+        r = self.session.get(
+            '%s/api/v1/identities/%s/' % (self.base_url, uuid))
+        if r.status_code == 404:
+            return None
+        return r.json()
+
     def get_addresses(self, uuid):
-        '''Get the list of addresses for an identity specified by uuid.'''
+        '''Get the list of addresses that a message to an identity specified
+        by uuid should be sent to.'''
+        identity = self.get_identity(uuid)
+        if identity and identity.get('communicate_through') is not None:
+            return self.get_addresses(identity['communicate_through'])
         addresses = self.get_paginated_response(
             '%s/api/v1/identities/%s/addresses/%s' % (
                 self.base_url, uuid, self.address_type),

--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -158,7 +158,7 @@ class JunebugBackendTest(BaseCasesTest):
             'http://localhost:8080/channels/replace-me/messages/',
             callback=junebug_callback, content_type='application/json')
 
-        def identity_store_callback(request):
+        def identity_address_callback(request):
             headers = {'Content-Type': 'application/json'}
             resp = {
                 "count": 1,
@@ -175,10 +175,31 @@ class JunebugBackendTest(BaseCasesTest):
             responses.GET,
             'http://localhost:8081/api/v1/identities/%s/addresses/msisdn' % (
                 bob.uuid),
-            callback=identity_store_callback, content_type='application/json')
+            callback=identity_address_callback,
+            content_type='application/json')
+
+        def identity_callback(request):
+            headers = {'Content-Type': 'application/json'}
+            resp = {
+                "id": bob.uuid,
+                "version": 1,
+                "details": {
+                },
+                "communicate_through": None,
+                "operator": None,
+                "created_at": "2016-06-23T13:03:18.674016Z",
+                "created_by": 1,
+                "updated_at": "2016-06-23T13:03:18.674043Z",
+                "updated_by": 1
+            }
+            return 200, headers, json.dumps(resp)
+        responses.add_callback(
+            responses.GET,
+            'http://localhost:8081/api/v1/identities/%s/' % bob.uuid,
+            callback=identity_callback, content_type='application/json')
 
         self.backend.push_outgoing(self.unicef, [msg])
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 3)
 
     @responses.activate
     @override_settings(JUNEBUG_FROM_ADDRESS='+4321')
@@ -398,6 +419,28 @@ class IdentityStoreTest(BaseCasesTest):
             'addresses/msisdn?default=True', match_querystring=True,
             callback=request_callback, content_type='application/json')
 
+        def identity_callback(request):
+            headers = {'Content-Type': 'application/json'}
+            resp = {
+                "id": "identity-uuid",
+                "version": 1,
+                "details": {
+                },
+                "communicate_through": None,
+                "operator": None,
+                "created_at": "2016-06-23T13:03:18.674016Z",
+                "created_by": 1,
+                "updated_at": "2016-06-23T13:03:18.674043Z",
+                "updated_by": 1
+            }
+            return 200, headers, json.dumps(resp)
+        responses.add_callback(
+            responses.GET,
+            'http://identitystore.org/api/v1/identities/identity-uuid/',
+            callback=identity_callback, content_type='application/json')
+
+        res = identity_store.get_addresses('identity-uuid')
+        self.assertEqual(sorted(res), sorted(['+1234', '+4321']))
         res = identity_store.get_addresses('identity-uuid')
         self.assertEqual(sorted(res), sorted(['+1234', '+4321']))
 


### PR DESCRIPTION
Currently for the Junebug backend outbound messages, we check the identity for a list of addresses.

An identity, however, might have a communicate_through parameter, in which case we should get the addresses for the identity specified by communicate_through, instead of the current identity.