### PR TITLE
Remove Identity store deleted sync and tests

### DIFF
--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -214,7 +214,8 @@ class JunebugBackend(BaseBackend):
 
         identities_to_update = list(chain(modified_identities, new_identities))
 
-        # the method expects fetches not lists so I faked it
+        # sync_local_to_changes() expects iterables for the 3rd and 4th args
+        # Deleted identities are updated via the Identity Store callback
         return sync_local_to_changes(
             org, IdentityStoreContactSyncer(), [identities_to_update], [],
             progress_callback)

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -66,12 +66,10 @@ class IdentityStore(object):
             url, params=params)
 
         # Users who opt to be forgotten from the system have their details
-        # stored as 'redacted'. We only want to return them if we are
-        # specifically looking for forgotten users.
+        # stored as 'redacted'.
         return (
             IdentityStoreContact(i) for i in identities if
-            i.get('details').get('name') != "redacted" or
-            'optout_type' in params
+            i.get('details').get('name') != "redacted"
         )
 
 
@@ -216,15 +214,10 @@ class JunebugBackend(BaseBackend):
 
         identities_to_update = list(chain(modified_identities, new_identities))
 
-        # all identities deleted in the Identity Store in the time window
-        deleted_identities = list(identity_store.get_identities(
-            optout_type='forget', updated_from=modified_after,
-            updated_to=modified_before))
-
         # the method expects fetches not lists so I faked it
         return sync_local_to_changes(
-            org, IdentityStoreContactSyncer(), [identities_to_update],
-            [deleted_identities], progress_callback)
+            org, IdentityStoreContactSyncer(), [identities_to_update], [],
+            progress_callback)
 
     def pull_fields(self, org):
         """

--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -129,12 +129,6 @@ class JunebugBackendTest(BaseCasesTest):
             self.identity_store_no_matches_callback
         )
 
-        self.add_identity_store_callback(
-            'updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00&'
-            'optout_type=forget',
-            self.identity_store_no_matches_callback
-        )
-
         (created, updated, deleted, ignored) = self.backend.pull_contacts(
             self.unicef, '2016-03-14T10:25:00', '2016-03-14T10:21:00')
         self.assertEqual(created, 1)
@@ -160,12 +154,6 @@ class JunebugBackendTest(BaseCasesTest):
             self.identity_store_updated_identity_callback
         )
 
-        self.add_identity_store_callback(
-            'updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00&'
-            'optout_type=forget',
-            self.identity_store_no_matches_callback
-        )
-
         (created, updated, deleted, ignored) = self.backend.pull_contacts(
             self.unicef, '2016-03-14T10:25:00', '2016-03-14T10:21:00')
         self.assertEqual(created, 0)
@@ -178,24 +166,14 @@ class JunebugBackendTest(BaseCasesTest):
         self.assertEqual(contact.name, "test")
 
     @responses.activate
-    def test_pull_contacts_recently_deleted(self):
-        Contact.get_or_create(self.unicef, 'test_id', "test")
-        contact = Contact.objects.get(uuid='test_id')
-        self.assertTrue(contact.is_active)
-
+    def test_pull_contacts_forgotten(self):
         self.add_identity_store_callback(
             'created_to=2016-03-14T10%3A21%3A00&created_from=2016-03-14T10%3A25%3A00',
-            self.identity_store_no_matches_callback
+            self.identity_store_forgotten_identity_callback
         )
 
         self.add_identity_store_callback(
             'updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00',
-            self.identity_store_no_matches_callback
-        )
-
-        self.add_identity_store_callback(
-            'updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00&'
-            'optout_type=forget',
             self.identity_store_forgotten_identity_callback
         )
 
@@ -203,11 +181,9 @@ class JunebugBackendTest(BaseCasesTest):
             self.unicef, '2016-03-14T10:25:00', '2016-03-14T10:21:00')
         self.assertEqual(created, 0)
         self.assertEqual(updated, 0)
-        self.assertEqual(deleted, 1)
+        self.assertEqual(deleted, 0)
         self.assertEqual(ignored, 0)
-        self.assertEqual(Contact.objects.count(), 1)
-        contact = Contact.objects.get(uuid='test_id')
-        self.assertFalse(contact.is_active)
+        self.assertEqual(Contact.objects.count(), 0)
 
     @responses.activate
     def test_pull_contacts_no_changes(self):
@@ -222,12 +198,6 @@ class JunebugBackendTest(BaseCasesTest):
         self.add_identity_store_callback(
             'updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00',
             self.identity_store_updated_identity_callback
-        )
-
-        self.add_identity_store_callback(
-            'updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00&'
-            'optout_type=forget',
-            self.identity_store_no_matches_callback
         )
 
         (created, updated, deleted, ignored) = self.backend.pull_contacts(


### PR DESCRIPTION
Contacts won't be deleted in the Identity Store so we shouldn't sync deleted contacts. Opted out Identities will be sent to Casepro via a webhook and handled in a different PR.