### PR TITLE
Make UUID to int function only return positive integers

### DIFF
--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -129,10 +129,11 @@ def month_range(offset, now=None):
 def uuid_to_int(uuid):
     '''
     Converts a UUID hex string to an int within the range of a Django
-    IntegerField.
+    IntegerField, and also >=0, as the URL regexes don't account for
+    negative numbers.
 
     From https://docs.djangoproject.com/en/1.9/ref/models/fields/#integerfield
     "Values from -2147483648 to 2147483647 are safe in all databases supported
     by Django"
     '''
-    return UUID(hex=uuid).int % (2147483648 + 2147483647 + 1) - 2147483648
+    return UUID(hex=uuid).int % (2147483647 + 1)

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -94,20 +94,20 @@ class UtilsTest(BaseCasesTest):
 
     def test_uuid_to_int_range(self):
         '''Ensures that the integer returned will always be in the range
-        [-2147483648, 2147483647].'''
+        [0, 2147483647].'''
         self.assertEqual(
-            uuid_to_int(UUID(int=(2147483648 + 2147483647)).hex),
+            uuid_to_int(UUID(int=(2147483647)).hex),
             2147483647)
         self.assertEqual(
-            uuid_to_int(UUID(int=(2147483648 + 2147483647 + 1)).hex),
-            -2147483648)
+            uuid_to_int(UUID(int=(2147483648)).hex),
+            0)
 
     @given(st.uuids())
     def test_uuid_to_int_property(self, uuid):
         '''Property based testing to ensure that the output of the function
         is always within the limits.'''
         self.assertTrue(uuid_to_int(uuid.hex) <= 2147483647)
-        self.assertTrue(uuid_to_int(uuid.hex) >= -2147483648)
+        self.assertTrue(uuid_to_int(uuid.hex) >= 0)
 
 
 class MiddlewareTest(BaseCasesTest):


### PR DESCRIPTION
Currently, the `uuid_to_int` function turns a uuid into an integer within the range of an `IntegerField`. This causes problems as most of the url regexes don't account for negative IDs, so it results in 404s for messages with negative IDs. We need to change to `uuid_to_int` function to only return positive number.