### PR TITLE
Add base data pod angular components

### DIFF
--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -497,4 +497,33 @@ describe('controllers:', () ->
       expect(UtilsService.navigateBack).toHaveBeenCalled()
     )
   )
+
+
+  describe('PodController', () ->
+    $scope = null
+
+    beforeEach(() ->
+      $scope = $rootScope.$new()
+    )
+
+    it('should attach pod data to the scope', () ->
+      $scope.podId = 21
+
+      PodApi = new class PodApi
+        get: ->
+
+      p = $q.resolve({foo: 'bar'})
+      spyOn(PodApi, 'get').and.returnValue(p)
+
+      $controller('PodController', {
+        $scope
+        PodApi
+      })
+
+      return p
+        .then(() ->
+          expect(PodApi.get).toHaveBeenCalledWith(21)
+          expect($scope.pod).toEqual({foo: 'bar'}))
+    )
+  )
 )

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -530,4 +530,40 @@ describe('services:', () ->
       )
     )
   )
+
+  #=======================================================================
+  # Tests for PodApi
+  #=======================================================================
+  describe('PodApi', () ->
+    PodApi = null
+
+    beforeEach(inject((_PodApi_) ->
+      PodApi = _PodApi_
+      $window.contextData = {case_obj: {id: 23}}
+    ))
+
+    describe('get', () ->
+      it('gets a pod', () ->
+        $httpBackend.expectGET('/pods/read/21/?case_id=23')
+          .respond({foo: 'bar'})
+
+        PodApi.get(21, 23)
+          .then((res) -> expect(res).toEqual({foo: 'bar'}))
+
+        $httpBackend.flush()
+      )
+
+      it('defaults the case id to the global case id', ->
+        $window.contextData = {case_obj: {id: 23}}
+
+        $httpBackend.expectGET('/pods/read/21/?case_id=23')
+          .respond({foo: 'bar'})
+
+        PodApi.get(21)
+          .then((res) -> expect(res).toEqual({foo: 'bar'}))
+
+        $httpBackend.flush()
+      )
+    )
+  )
 )

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -637,3 +637,12 @@ controllers.controller('DateRangeController', ['$scope', ($scope) ->
     $event.stopPropagation()
     $scope.beforeOpen = true
 ])
+
+
+#============================================================================
+# Pod controller
+#============================================================================
+controllers.controller('PodController', ['$scope', 'PodApi', ($scope, PodApi) ->
+  PodApi.get($scope.podId)
+    .then((pod) -> $scope.pod = pod)
+])

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -416,3 +416,15 @@ services.factory('UtilsService', ['$window', '$uibModal', ($window, $uibModal) -
       resolve = {summaryInitial: (() -> summaryInitial), summaryMaxLength: (() -> summaryMaxLength), partners: (() -> partners)}
       return $uibModal.open({templateUrl: '/partials/modal_newcase.html', controller: 'NewCaseModalController', resolve: resolve}).result
 ])
+
+
+#=====================================================================
+# Pod API service
+#=====================================================================
+services.factory('PodApi', ['$window', '$http', ($window, $http) ->
+  new class PodApi
+    get: (podId, caseId = null) ->
+      caseId ?= $window.contextData.case_obj.id
+      $http.get("/pods/read/#{podId}/", {params: {case_id: caseId}})
+        .then((d) -> d.data)
+])


### PR DESCRIPTION
We need the following in angular land for data pods:
  - a service for retrieving data for a pod
  - a base/default controller for pods that uses the pod data retrieval service and assigns its response to the scope
  - a base/default directive for pods that formats a pod's data as a list of field-value pairs