### PR TITLE
Rename pod directive to cpPod

### DIFF
--- a/casepro/pods/base.py
+++ b/casepro/pods/base.py
@@ -56,7 +56,7 @@ class PodPlugin(AppConfig):
     controller = 'PodController'
 
     # override to use a different angular directive
-    directive = 'pod'
+    directive = 'cp-pod'
 
     # override with paths to custom scripts that the pod needs
     scripts = ()

--- a/karma/test-directives.coffee
+++ b/karma/test-directives.coffee
@@ -4,7 +4,7 @@ describe('directives:', () ->
   #=======================================================================
   # Tests for pod
   #=======================================================================
-  describe('pod', () ->
+  describe('cpPod', () ->
     $rootScope = null
     $compile = null
 
@@ -22,7 +22,7 @@ describe('directives:', () ->
     it('should draw the pod items', () ->
       $rootScope.podConfig.title = 'Foo'
 
-      el = $compile('<div pod></div>')($rootScope)[0]
+      el = $compile('<div cp-pod></div>')($rootScope)[0]
       $rootScope.$digest()
 
       expect(el.querySelector('.pod-title').textContent).toContain('Foo')
@@ -39,7 +39,7 @@ describe('directives:', () ->
         }]
       }
 
-      el = $compile('<div pod></div>')($rootScope)[0]
+      el = $compile('<div cp-pod></div>')($rootScope)[0]
       $rootScope.$digest()
 
       item1 = el.querySelector('.pod-item:nth-child(1)')

--- a/static/coffee/directives.coffee
+++ b/static/coffee/directives.coffee
@@ -7,6 +7,6 @@ directives = angular.module('cases.directives', [])
 #=====================================================================
 # Pod directive
 #=====================================================================
-directives.directive('pod', -> {
+directives.directive('cpPod', -> {
   templateUrl: -> '/sitestatic/templates/pod.html'
 })


### PR DESCRIPTION
To be consistent with the naming convention used for `cpContact`.