### PR TITLE
Update PodApi service sending of actions request to match api change

### DIFF
--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -637,16 +637,19 @@ describe('services:', () ->
 
     describe('trigger', () ->
       it('triggers an action', () ->
-        $httpBackend.expectPUT('/pods/action/21/', {
+        $httpBackend.expectPOST('/pods/action/21/', {
             data: {
-              type: 'foo',
-              payload: {bar: 23}
+              case_id: 23,
+              action: {
+                type: 'foo',
+                payload: {bar: 'baz'}
+              }
             }
           })
-          .respond({foo: 'bar'})
+          .respond({quux: 'corge'})
 
-        PodApi.trigger(21, 'foo', {bar: 23})
-          .then((res) -> expect(res).toEqual({foo: 'bar'}))
+        PodApi.trigger(21, 23, 'foo', {bar: 'baz'})
+          .then((res) -> expect(res).toEqual({quux: 'corge'}))
 
         $httpBackend.flush()
       )

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -638,12 +638,10 @@ describe('services:', () ->
     describe('trigger', () ->
       it('triggers an action', () ->
         $httpBackend.expectPOST('/pods/action/21/', {
-            data: {
-              case_id: 23,
-              action: {
-                type: 'foo',
-                payload: {bar: 'baz'}
-              }
+            case_id: 23,
+            action: {
+              type: 'foo',
+              payload: {bar: 'baz'}
             }
           })
           .respond({quux: 'corge'})

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -550,11 +550,14 @@ services.factory('PodApi', ['$window', '$http', ($window, $http) ->
       $http.get("/pods/read/#{podId}/", {params: {case_id: caseId}})
         .then((d) -> d.data)
 
-    trigger: (podId, type, payload = {}) ->
-      $http.put("/pods/action/#{podId}/", {
+    trigger: (podId, caseId, type, payload = {}) ->
+      $http.post("/pods/action/#{podId}/", {
           data: {
-            type,
-            payload
+            case_id: caseId
+            action: {
+              type,
+              payload
+            }
           }
         })
         .then((d) -> d.data)

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -552,13 +552,11 @@ services.factory('PodApi', ['$window', '$http', ($window, $http) ->
 
     trigger: (podId, caseId, type, payload = {}) ->
       $http.post("/pods/action/#{podId}/", {
-          data: {
-            case_id: caseId
-            action: {
-              type,
-              payload
-            }
-          }
-        })
-        .then((d) -> d.data)
+        case_id: caseId
+        action: {
+          type,
+          payload
+        }
+      })
+      .then((d) -> d.data)
 ])


### PR DESCRIPTION
The plan is to change the service to make actions requests that look something like this:

```
POST /pods/action/<pod_id>/
{
  case_id: <case_id>,
  action: {
    type: <action_type>,
    payload: {...}
  }
}
```