### PR TITLE
Update base pod controller to support triggering actions

### DIFF
--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -818,4 +818,19 @@ controllers.controller('PodController', ['$scope', 'PodApi', ($scope, PodApi) ->
   $scope.update = ->
     PodApi.get($scope.podId, $scope.caseId)
       .then((d) -> $scope.podData = d)
+
+  $scope.trigger = (type, payload) ->
+    PodApi.trigger($scope.podId, $scope.caseId, type, payload)
+      .then(({success, payload}) ->
+        if success
+          $scope.onTriggerSuccess()
+        else
+          $scope.onTriggerFailure(payload))
+
+  $scope.onTriggerFailure = (payload) ->
+    # TODO show failure message
+
+  $scope.onTriggerSuccess = () ->
+    # TODO update notes
+    $scope.update()
 ])

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -813,7 +813,9 @@ controllers.controller('PodController', ['$scope', 'PodApi', ($scope, PodApi) ->
     $scope.podId = podId
     $scope.caseId = caseId
     $scope.podConfig = podConfig
+    $scope.update()
 
-    return PodApi.get(podId, caseId)
+  $scope.update = ->
+    PodApi.get($scope.podId, $scope.caseId)
       .then((d) -> $scope.podData = d)
 ])


### PR DESCRIPTION
We need to change the base pod controller to:
  - support triggering actions
  - fetch new pod data after an action has been triggered, and update the scope with the new data