### PR TITLE
Update case actions after triggering a pod action

### DIFF
--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -84,6 +84,11 @@ describe('controllers:', () ->
       expect($scope.contact).toEqual(test.ann)
     )
 
+    it('should should broadcast timelineChanged on podActionSuccess', (done) ->
+      $scope.$on('timelineChanged', -> done())
+      $scope.$emit('podActionSuccess')
+    )
+
     it('addNote', () ->
       noteModal = spyOnPromise($q, $scope, UtilsService, 'noteModal')
       addNote = spyOnPromise($q, $scope, CaseService, 'addNote')
@@ -723,6 +728,25 @@ describe('controllers:', () ->
 
         expect(PodApi.trigger)
           .toHaveBeenCalledWith(21, 23, 'grault', {garply: 'waldo'})
+      )
+
+      it('should emit a podActionSuccess event if successful', (done) ->
+        $scope.podId = 21
+        $scope.caseId = 23
+        $scope.podConfig = {title: 'Foo'}
+        $scope.podData = {bar: 'baz'}
+
+        $controller('PodController', {
+          $scope
+          PodApi
+        })
+
+        spyOn(PodApi, 'trigger').and.returnValue($q.resolve({success: true}))
+        $scope.trigger('grault', {garply: 'waldo'})
+
+        $scope.$on('podActionSuccess', -> done())
+
+        $scope.$apply()
       )
 
       it('should fetch and attach data to the scope if successful', () ->

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -84,9 +84,10 @@ describe('controllers:', () ->
       expect($scope.contact).toEqual(test.ann)
     )
 
-    it('should should broadcast timelineChanged on podActionSuccess', (done) ->
+    it('should should proxy timelineChanged events from child scopes', (done) ->
       $scope.$on('timelineChanged', -> done())
-      $scope.$emit('podActionSuccess')
+      child = $scope.$new(false)
+      child.$emit('timelineChanged')
     )
 
     it('addNote', () ->
@@ -734,7 +735,7 @@ describe('controllers:', () ->
           .toHaveBeenCalledWith(21, 23, 'grault', {garply: 'waldo'})
       )
 
-      it('should emit a podActionSuccess event if successful', (done) ->
+      it('should emit a timelineChanged event if successful', (done) ->
         $scope.podId = 21
         $scope.caseId = 23
         $scope.podConfig = {title: 'Foo'}
@@ -748,7 +749,7 @@ describe('controllers:', () ->
         spyOn(PodApi, 'trigger').and.returnValue($q.resolve({success: true}))
         $scope.trigger('grault', {garply: 'waldo'})
 
-        $scope.$on('podActionSuccess', -> done())
+        $scope.$on('timelineChanged', -> done())
 
         $scope.$apply()
       )

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -517,7 +517,8 @@ controllers.controller('CaseController', ['$scope', '$window', '$timeout', 'Case
 
     $scope.refresh()
 
-  $scope.$on('podActionSuccess', -> $scope.$broadcast('timelineChanged'))
+  $scope.$on('timelineChange', (e) ->
+    $scope.$broadcast('timelineChanged') if e.targetScope != $scope)
 
   $scope.refresh = () ->
     CaseService.fetchSingle($scope.caseId).then((caseObj) ->
@@ -845,6 +846,6 @@ controllers.controller('PodController', ['$scope', 'PodApi', ($scope, PodApi) ->
     # TODO show failure message
 
   $scope.onTriggerSuccess = () ->
-    $scope.$emit('podActionSuccess')
+    $scope.$emit('timelineChanged')
     $scope.update()
 ])

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -502,6 +502,8 @@ controllers.controller('CaseController', ['$scope', '$window', '$timeout', 'Case
 
     $scope.refresh()
 
+  $scope.$on('podActionSuccess', -> $scope.$broadcast('timelineChanged'))
+
   $scope.refresh = () ->
     CaseService.fetchSingle($scope.caseId).then((caseObj) ->
       $scope.caseObj = caseObj
@@ -831,6 +833,6 @@ controllers.controller('PodController', ['$scope', 'PodApi', ($scope, PodApi) ->
     # TODO show failure message
 
   $scope.onTriggerSuccess = () ->
-    # TODO update notes
+    $scope.$emit('podActionSuccess')
     $scope.update()
 ])


### PR DESCRIPTION
Triggering a pod action causes a new note to be created for the case. We need to be able to redraw the case actions once an action has been triggered to draw the new note.