### PR TITLE
Use `[[`s in angular templates

### DIFF
--- a/static/templates/pod.html
+++ b/static/templates/pod.html
@@ -1,11 +1,11 @@
 <div class="panel panel-default">
-    <div class="pod-title panel-heading">{{ podConfig.title }}</div>
+    <div class="pod-title panel-heading">[[ podConfig.title ]]</div>
 
     <div class="list-group">
         <div class="container-fluid">
             <div class="pod-item list-group-item row" ng-repeat="item in podData.items">
-                <div class="pod-item-name col-sm-6">{{ item.name }}</div>
-                <div class="pod-item-value col-sm-6">{{ item.value }}</div>
+                <div class="pod-item-name col-sm-6">[[ item.name ]]</div>
+                <div class="pod-item-value col-sm-6">[[ item.value ]]</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
At the moment we use `{{`s, which angular accepts, but the convention in this project is to use `[[`s.