### PR TITLE
Pod actions remain disabled after unhandled errors

### DIFF
--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -999,6 +999,32 @@ describe('controllers:', () ->
         expect($scope.podData.actions[0].isBusy).toBe(true)
       )
 
+      it('should mark the action as not busy after api failure', () ->
+        $scope.podData.actions = [{
+          type: 'grault'
+          isBusy: false,
+          payload: {}
+        }, {
+          type: 'fred',
+          isBusy: false,
+          payload: {}
+        }]
+
+        bindController()
+
+        spyOn(PodApiService, 'get')
+          .and.returnValue($q.reject(new PodApiServiceError(null)))
+
+        $scope.trigger({
+          type: 'grault',
+          payload: {garply: 'waldo'}
+        })
+
+        $scope.$apply()
+
+        expect($scope.podData.actions[0].isBusy).toBe(false)
+      )
+
       it('should emit a notification event if unsuccessful', (done) ->
         bindController()
 


### PR DESCRIPTION
We need to un-disable when action completes, regardless of the result.