### PR TITLE
Include user's name on pod action case actions

### DIFF
--- a/casepro/pods/tests/test_views.py
+++ b/casepro/pods/tests/test_views.py
@@ -166,6 +166,7 @@ class PerformPodActionView(BaseCasesTest):
             })
 
         self.assertEqual(response.status_code, 200)
+
         message = "Type foo Params {u'foo': u'bar'}"
         self.assertEqual(response.json, {
             'success': True,
@@ -173,5 +174,8 @@ class PerformPodActionView(BaseCasesTest):
                 'message': message
             }
         })
+
         [caseaction] = CaseAction.objects.all()
-        self.assertEqual(caseaction.note, message)
+        self.assertEqual(
+            caseaction.note,
+            "%s %s" % (self.admin.username, message))

--- a/casepro/pods/views.py
+++ b/casepro/pods/views.py
@@ -7,6 +7,9 @@ from casepro.cases.models import Case, CaseAction
 from casepro.pods import registry
 
 
+ACTION_NOTE_CONTENT = "%(username)s %(message)s"
+
+
 def read_pod_data(request, index):
     """Delegates to the `read_data` function of the correct pod."""
     if request.method != 'GET':
@@ -47,6 +50,10 @@ def perform_pod_action(request, index):
     success, payload = pod.perform_action(action_data.get('type'), action_data.get('payload', {}))
     if success is True:
         case = Case.objects.get(id=case_id)
-        CaseAction.create(case, request.user, CaseAction.ADD_NOTE, note=payload.get('message'))
+        note = ACTION_NOTE_CONTENT % {
+            'username': request.user.username,
+            'message': payload.get('message'),
+        }
+        CaseAction.create(case, request.user, CaseAction.ADD_NOTE, note=note)
 
     return JsonResponse({'success': success, 'payload': payload})


### PR DESCRIPTION
We need to record the user's name on the case action we record when the user triggers a pod action.