### PR TITLE
Add user selection when creating case

### DIFF
--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -222,7 +222,7 @@ class Case(models.Model):
         return queryset.order_by('-opened_on')
 
     @classmethod
-    def get_or_open(cls, org, user, message, summary, assignee):
+    def get_or_open(cls, org, user, message, summary, assignee, user_assignee=None):
         from casepro.profiles.models import Notification
 
         r = get_redis_connection()
@@ -238,7 +238,7 @@ class Case(models.Model):
             message.contact.prepare_for_case()
 
             case = cls.objects.create(org=org, assignee=assignee, initial_message=message, contact=message.contact,
-                                      summary=summary)
+                                      summary=summary, user_assignee=user_assignee)
             case.is_new = True
             case.labels.add(*list(message.labels.all()))  # copy labels from message to new case
             case.watchers.add(user)

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -399,7 +399,8 @@ class CaseCRUDLTest(BaseCasesTest):
         # log in as an administrator
         self.login(self.admin)
 
-        response = self.url_post_json('unicef', url, {'message': 101, 'summary': "Summary", 'assignee': self.moh.pk})
+        response = self.url_post_json('unicef', url, {
+            'message': 101, 'summary': "Summary", 'assignee': self.moh.pk, 'user_assignee': self.user1.pk})
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.json['summary'], "Summary")
@@ -410,6 +411,7 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(case1.initial_message, msg1)
         self.assertEqual(case1.summary, "Summary")
         self.assertEqual(case1.assignee, self.moh)
+        self.assertEqual(case1.user_assignee, self.user1)
         self.assertEqual(set(case1.labels.all()), {self.aids})
 
         # try again as a non-administrator who can't create cases for other partner orgs
@@ -427,6 +429,19 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(case2.summary, "Summary")
         self.assertEqual(case2.assignee, self.moh)
         self.assertEqual(set(case2.labels.all()), {self.aids})
+
+    def test_open_user_assignee_not_member_of_partner(self):
+        """
+        If the user specified in user_assignee is not a member of the partner specified by assignee, then a not found
+        error should be returned.
+        """
+        self.login(self.admin)
+        msg = self.create_message(self.unicef, 102, self.ann, "Hello", [self.aids])
+
+        response = self.url_post_json('unicef', reverse('cases.case_open'), {
+            'message': msg.backend_id, 'summary': "Summary", 'assignee': self.moh.pk, 'user_assignee': self.user3.pk
+            })
+        self.assertEqual(response.status_code, 404)
 
     def test_read(self):
         url = reverse('cases.case_read', args=[self.case.pk])

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -92,15 +92,19 @@ class CaseCRUDL(SmartCRUDL):
             summary = request.json['summary']
 
             assignee_id = request.json.get('assignee', None)
+            user_assignee = request.json.get('user_assignee', None)
             if assignee_id:
                 assignee = Partner.get_all(request.org).get(pk=assignee_id)
+                if user_assignee:
+                    user_assignee = get_object_or_404(assignee.get_users(), pk=user_assignee)
             else:
                 assignee = request.user.get_partner(self.request.org)
+                user_assignee = request.user
 
             message_id = int(request.json['message'])
             message = Message.objects.get(org=request.org, backend_id=message_id)
 
-            case = Case.get_or_open(request.org, request.user, message, summary, assignee)
+            case = Case.get_or_open(request.org, request.user, message, summary, assignee, user_assignee=user_assignee)
 
             # augment regular case JSON
             case_json = case.as_json()

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -207,17 +207,19 @@ describe('controllers:', () ->
     OutgoingService = null
     CaseService = null
     PartnerService = null
+    UserService = null
 
     $inboxScope = null
     $scope = null
     serverTime = 1464775597109  # ~ Jun 1st 2016 10:06:37 UTC
 
     beforeEach(() ->
-      inject((_MessageService_, _OutgoingService_, _CaseService_, _PartnerService_) ->
+      inject((_MessageService_, _OutgoingService_, _CaseService_, _PartnerService_, _UserService_) ->
         MessageService = _MessageService_
         OutgoingService = _OutgoingService_
         CaseService = _CaseService_
         PartnerService = _PartnerService_
+        UserService = _UserService_
       )
 
       $window.contextData = {user: test.user1, partners: [], labels: [test.tea, test.coffee], groups: []}
@@ -433,15 +435,18 @@ describe('controllers:', () ->
           fetchPartners = spyOnPromise($q, $scope, PartnerService, 'fetchAll')
           newCaseModal = spyOnPromise($q, $scope, UtilsService, 'newCaseModal')
           openCase = spyOnPromise($q, $scope, CaseService, 'open')
+          fetchUsersForPartner = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
           spyOn(UtilsService, 'navigate')
 
           $scope.onCaseFromMessage(test.msg1)
 
           fetchPartners.resolve([test.moh, test.who])
-          newCaseModal.resolve({summary: "New case", assignee: test.moh})
+          fetchUsersForPartner.resolve([test.user1])
+          newCaseModal.resolve({summary: "New case", assignee: test.moh, user: test.user1})
           openCase.resolve({id: 601, summary: "New case", isNew: false})
 
-          expect(CaseService.open).toHaveBeenCalledWith(test.msg1, "New case", test.moh)
+          expect(UserService.fetchInPartner).toHaveBeenCalledWith(test.moh, true)
+          expect(CaseService.open).toHaveBeenCalledWith(test.msg1, "New case", test.moh, test.user1)
           expect(UtilsService.navigate).toHaveBeenCalledWith('/case/read/601/?alert=open_found_existing')
         )
 

--- a/karma/test-modals.coffee
+++ b/karma/test-modals.coffee
@@ -157,21 +157,38 @@ describe('modals:', () ->
   )
 
   it('NewCaseModalController', () ->
-    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who]})
+    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who], users: [test.user1]})
 
     expect($scope.fields.summary).toEqual({val: "Hello", maxLength: 10})
     expect($scope.fields.assignee).toEqual({val: test.moh})
+    expect($scope.fields.user).toEqual({val: {id: null, name: "Anyone"}})
+    expect($scope.partners).toEqual([test.moh, test.who])
+    expect($scope.users).toEqual([{id: null, name: "Anyone"}].concat([test.user1]))
 
     $scope.fields.summary.val = "Interesting"
     $scope.fields.assignee.val = test.who
+    $scope.fields.user.val = test.user1
     $scope.form = {$valid: true}
     $scope.ok()
 
-    expect(modalInstance.close).toHaveBeenCalledWith({summary: "Interesting", assignee: test.who})
+    expect(modalInstance.close).toHaveBeenCalledWith({summary: "Interesting", assignee: test.who, user: test.user1})
 
     $scope.cancel()
 
     expect(modalInstance.dismiss).toHaveBeenCalledWith(false)
+  )
+
+  it('NewCaseModalController.refreshUserList', () ->
+    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who], users: []})
+
+    usersForPartner = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
+
+    expect($scope.users).toEqual([{id: null, name: "Anyone"}])
+
+    $scope.refreshUserList()
+    usersForPartner.resolve([test.user1])
+
+    expect($scope.users).toEqual([{id: null, name: "Anyone"}, test.user1])
   )
 
   it('NoteModalController', () ->

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -118,8 +118,8 @@ describe('services:', () ->
 
     describe('open', () ->
       it('posts to open endpoint', () ->
-        $httpBackend.expectPOST('/case/open/', {message: 401, summary: "Hi", assignee: 301}).respond('{"id": 501, "is_new": true, "watching": true}')
-        CaseService.open({id: 401, text: "Hi"}, "Hi", test.moh).then((caseObj) ->
+        $httpBackend.expectPOST('/case/open/', {message: 401, summary: "Hi", assignee: 301, user_assignee: test.user1.id}).respond('{"id": 501, "is_new": true, "watching": true}')
+        CaseService.open({id: 401, text: "Hi"}, "Hi", test.moh, test.user1).then((caseObj) ->
           expect(caseObj.id).toEqual(501)
           expect(caseObj.is_new).toEqual(true)
           expect(caseObj.watching).toEqual(true)

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -208,7 +208,7 @@ controllers.controller('BaseItemsController', ['$scope', 'UtilsService', ($scope
 #============================================================================
 # Incoming messages controller
 #============================================================================
-controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal', '$controller', 'CaseService', 'MessageService', 'PartnerService', 'UtilsService', ($scope, $timeout, $uibModal, $controller, CaseService, MessageService, PartnerService, UtilsService) ->
+controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal', '$controller', 'CaseService', 'MessageService', 'PartnerService', 'UserService', 'UtilsService', ($scope, $timeout, $uibModal, $controller, CaseService, MessageService, PartnerService, UserService, UtilsService) ->
   $controller('BaseItemsController', {$scope: $scope})
 
   $scope.advancedSearch = false
@@ -355,12 +355,15 @@ controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal',
     }})
 
   newCaseFromMessage = (message, possibleAssignees) ->
-    UtilsService.newCaseModal(message.text, CASE_SUMMARY_MAX_LEN, possibleAssignees).then((data) ->
-      CaseService.open(message, data.summary, data.assignee).then((caseObj) ->
-          caseUrl = '/case/read/' + caseObj.id + '/'
-          if !caseObj.is_new
-            caseUrl += '?alert=open_found_existing'
-          UtilsService.navigate(caseUrl)
+    assignee = if possibleAssignees then possibleAssignees[0] else null
+    UserService.fetchInPartner(assignee, true).then((users) ->
+      UtilsService.newCaseModal(message.text, CASE_SUMMARY_MAX_LEN, possibleAssignees, users).then((data) ->
+        CaseService.open(message, data.summary, data.assignee, data.user).then((caseObj) ->
+            caseUrl = '/case/read/' + caseObj.id + '/'
+            if !caseObj.is_new
+              caseUrl += '?alert=open_found_existing'
+            UtilsService.navigate(caseUrl)
+        )
       )
     )
 ])

--- a/static/coffee/modals.coffee
+++ b/static/coffee/modals.coffee
@@ -72,17 +72,33 @@ modals.controller('ReplyModalController', ['$scope', '$uibModalInstance', 'maxLe
 #=====================================================================
 # Open new case modal
 #=====================================================================
-modals.controller 'NewCaseModalController', ['$scope', '$uibModalInstance', 'summaryInitial', 'summaryMaxLength', 'partners', ($scope, $uibModalInstance, summaryInitial, summaryMaxLength, partners) ->
+modals.controller 'NewCaseModalController', ['$scope', '$uibModalInstance', 'summaryInitial', 'summaryMaxLength', 'partners', 'users', 'UserService', ($scope, $uibModalInstance, summaryInitial, summaryMaxLength, partners, users, UserService) ->
   $scope.partners = partners
+
+  userListFromUsers = (users) ->
+    return [{id: null, name: "Anyone"}].concat(users)
+
+  $scope.users = userListFromUsers(users)
+
   $scope.fields = {
     summary: {val: summaryInitial, maxLength: summaryMaxLength},
-    assignee: {val: if partners then partners[0] else null}
+    assignee: {val: if partners then partners[0] else null},
+    user: {val: $scope.users[0]}
   }
+
+  $scope.refreshUserList = () ->
+    UserService.fetchInPartner($scope.fields.assignee.val, true).then((users) ->
+      $scope.users = userListFromUsers(users)
+    )
 
   $scope.ok = () ->
     $scope.form.submitted = true
     if $scope.form.$valid
-      $uibModalInstance.close({summary: $scope.fields.summary.val, assignee: $scope.fields.assignee.val})
+      $uibModalInstance.close({
+        summary: $scope.fields.summary.val,
+        assignee: $scope.fields.assignee.val,
+        user: $scope.fields.user.val
+      })
   $scope.cancel = () -> $uibModalInstance.dismiss(false)
 ]
 

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -251,10 +251,12 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
     #----------------------------------------------------------------------------
     # Opens a new case
     #----------------------------------------------------------------------------
-    open: (message, summary, assignee) ->
+    open: (message, summary, assignee, user) ->
       params = {message: message.id, summary: summary}
       if assignee
         params.assignee = assignee.id
+      if user
+        params.user_assignee = user.id
 
       return $http.post('/case/open/', params).then((response) ->
         return response.data

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -546,8 +546,8 @@ services.factory('UtilsService', ['$window', '$uibModal', ($window, $uibModal) -
       resolve = {title: (() -> title), prompt: (() -> prompt), labels: (() -> labels), initial: (() -> initial)}
       return $uibModal.open({templateUrl: '/partials/modal_label.html', controller: 'LabelModalController', resolve: resolve}).result
 
-    newCaseModal: (summaryInitial, summaryMaxLength, partners) ->
-      resolve = {summaryInitial: (() -> summaryInitial), summaryMaxLength: (() -> summaryMaxLength), partners: (() -> partners)}
+    newCaseModal: (summaryInitial, summaryMaxLength, partners, users) ->
+      resolve = {summaryInitial: (() -> summaryInitial), summaryMaxLength: (() -> summaryMaxLength), partners: (() -> partners), users: (() -> users)}
       return $uibModal.open({templateUrl: '/partials/modal_newcase.html', controller: 'NewCaseModalController', resolve: resolve}).result
 
     dateRangeModal: (title, prompt) ->

--- a/templates/partials/modal_newcase.haml
+++ b/templates/partials/modal_newcase.haml
@@ -18,8 +18,9 @@
           - trans "Too long"
       .form-group{ ng-if:"partners != null" }
         %label.control-label
-          - trans "Assign to"
-        %select.form-control{ ng-model:"fields.assignee.val", ng-options:"p.name for p in partners track by p.id" }
+          - trans "Assign to partner/user"
+        %select.form-control{ ng-model:"fields.assignee.val", ng-options:"p.name for p in partners track by p.id", ng-change:"refreshUserList()" }
+        %select.form-control{ ng-model:"fields.user.val", ng-options:"u.name for u in users track by u.id" }
   .modal-footer
     %button.btn.btn-primary{ ng-click:"ok()" }
       - trans "Open"


### PR DESCRIPTION
We have added the ability to assign a user to a case when reassigning a case, now we should add the ability to assign a user to case when creating the case.

The plan of action is to add the user dropdown field to the modal used to create cases, similarly to how we added it to the modal for reassigning a case.