### PR TITLE
Show assigned user in case list

### DIFF
--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -430,6 +430,7 @@ class Case(models.Model):
             return {
                 'id': self.pk,
                 'assignee': self.assignee.as_json(full=False),
+                'user_assignee': self.user_assignee.as_json(full=False) if self.user_assignee else None,
                 'contact': self.contact.as_json(full=False),
                 'labels': [l.as_json(full=False) for l in self.labels.all()],
                 'summary': self.summary,
@@ -440,6 +441,7 @@ class Case(models.Model):
             return {
                 'id': self.pk,
                 'assignee': self.assignee.as_json(full=False),
+                'user_assignee': self.user_assignee.as_json(full=False) if self.user_assignee else None,
             }
 
     def __str__(self):

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -380,8 +380,9 @@ class CaseCRUDLTest(BaseCasesTest):
         self.ann = self.create_contact(self.unicef, 'C-001', "Ann",
                                        fields={'age': "34"}, groups=[self.females, self.reporters])
 
-        msg = self.create_message(self.unicef, 101, self.ann, "Hello", [self.aids])
-        self.case = self.create_case(self.unicef, self.ann, self.moh, msg, [self.aids], summary="Summary")
+        self.msg = self.create_message(self.unicef, 101, self.ann, "Hello", [self.aids])
+        self.case = self.create_case(
+            self.unicef, self.ann, self.moh, self.msg, [self.aids], summary="Summary", user_assignee=self.user1)
 
     @patch('casepro.test.TestBackend.archive_contact_messages')
     @patch('casepro.test.TestBackend.stop_runs')
@@ -689,7 +690,8 @@ class CaseCRUDLTest(BaseCasesTest):
             'summary': "Summary",
             'opened_on': format_iso8601(self.case.opened_on),
             'is_closed': False,
-            'watching': False
+            'watching': False,
+            'user_assignee': {'id': self.user1.pk, 'name': "Evan"},
         })
 
         # users with label access can also fetch
@@ -875,6 +877,7 @@ class CaseCRUDLTest(BaseCasesTest):
             {
                 'id': case2.pk,
                 'assignee': {'id': self.who.pk, 'name': "WHO"},
+                'user_assignee': None,
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'labels': [],
                 'summary': "",
@@ -884,6 +887,7 @@ class CaseCRUDLTest(BaseCasesTest):
             {
                 'id': self.case.pk,
                 'assignee': {'id': self.moh.pk, 'name': "MOH"},
+                'user_assignee': {'id': self.user1.pk, 'name': "Evan"},
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'labels': [{'id': self.aids.pk, 'name': "AIDS"}],
                 'summary': "Summary",
@@ -900,6 +904,7 @@ class CaseCRUDLTest(BaseCasesTest):
             {
                 'id': self.case.pk,
                 'assignee': {'id': self.moh.pk, 'name': "MOH"},
+                'user_assignee': {'id': self.user1.pk, 'name': "Evan"},
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'labels': [{'id': self.aids.pk, 'name': "AIDS"}],
                 'summary': "Summary",

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -718,7 +718,7 @@ class MessageCRUDLTest(BaseCasesTest):
         # labelled and cased/archived
         self.create_message(self.unicef, 104, self.bob, "raids", [self.aids], is_handled=True, is_archived=True)
         msg5 = self.create_message(self.unicef, 105, cat, "AIDS??", [self.aids], is_handled=True, is_archived=True)
-        case = self.create_case(self.unicef, cat, self.moh, msg5)
+        case = self.create_case(self.unicef, cat, self.moh, msg5, user_assignee=self.user1)
 
         # unlabelled
         self.create_message(self.unicef, 106, don, "RapidCon 2016", is_handled=True)
@@ -759,7 +759,8 @@ class MessageCRUDLTest(BaseCasesTest):
         self.assertEqual(response.json['results'][0]['text'], "AIDS??")
         self.assertEqual(response.json['results'][0]['labels'], [{'id': self.aids.pk, 'name': "AIDS"}])
         self.assertEqual(response.json['results'][0]['case'], {
-            'id': case.pk, 'assignee': {'id': self.moh.pk, 'name': "MOH"}, 'user_assignee': None})
+            'id': case.pk, 'assignee': {'id': self.moh.pk, 'name': "MOH"},
+            'user_assignee': {'id': self.user1.pk, 'name': "Evan"}})
         self.assertEqual(response.json['results'][1]['id'], 104)
 
     @patch('casepro.test.TestBackend.flag_messages')

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -758,8 +758,8 @@ class MessageCRUDLTest(BaseCasesTest):
         self.assertEqual(response.json['results'][0]['contact'], {'id': cat.pk, 'name': "Cat"})
         self.assertEqual(response.json['results'][0]['text'], "AIDS??")
         self.assertEqual(response.json['results'][0]['labels'], [{'id': self.aids.pk, 'name': "AIDS"}])
-        self.assertEqual(response.json['results'][0]['case'], {'id': case.pk,
-                                                               'assignee': {'id': self.moh.pk, 'name': "MOH"}})
+        self.assertEqual(response.json['results'][0]['case'], {
+            'id': case.pk, 'assignee': {'id': self.moh.pk, 'name': "MOH"}, 'user_assignee': None})
         self.assertEqual(response.json['results'][1]['id'], 104)
 
     @patch('casepro.test.TestBackend.flag_messages')
@@ -1222,7 +1222,7 @@ class OutgoingCRUDLTest(BaseCasesTest):
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urn': None,
                 'text': "Hello 1",
-                'case': {'id': case.pk, 'assignee': {'id': self.moh.pk, 'name': "MOH"}},
+                'case': {'id': case.pk, 'assignee': {'id': self.moh.pk, 'name': "MOH"}, 'user_assignee': None},
                 'sender': {'id': self.user1.pk, 'name': "Evan"},
                 'time': format_iso8601(out1.created_on),
                 'reply_to': {

--- a/templates/cases/inbox_cases.haml
+++ b/templates/cases/inbox_cases.haml
@@ -29,6 +29,10 @@
             %span.label.label-warning
               [[ item.assignee.name ]]
             &nbsp;
+          %span.label-container{ ng-if:"item.user_assignee.name" }
+            %span.label.label-warning
+              [[ item.user_assignee.name ]]
+            &nbsp;
           %span.label-container{ ng-repeat:"label in filterDisplayLabels(item.labels)" }
             %span.label.label-success
               [[ label.name ]]


### PR DESCRIPTION
When viewing the list of cases, if there is also a user assigned to the case, we should show it next to the partner name.