### PR TITLE
Add user to assign case note

### DIFF
--- a/casepro/cases/migrations/0041_caseaction_user_assignee.py
+++ b/casepro/cases/migrations/0041_caseaction_user_assignee.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('cases', '0040_case_user_assignee'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='caseaction',
+            name='user_assignee',
+            field=models.ForeignKey(related_name='case_assigned_actions', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, help_text='The (optional) user that the case was assigned to.', null=True),
+        ),
+    ]

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -320,6 +320,18 @@ class CaseTest(BaseCasesTest):
         open_case = Case.get_open_for_contact_on(self.unicef, self.ann, datetime(2014, 1, 16, 0, 0, tzinfo=pytz.UTC))
         self.assertEqual(open_case, case2)
 
+    def test_get_open_with_user_assignee(self):
+        '''If a case is opened with the user_assignee field set, the created case should have the assigned user, and
+        the created case action should also have the assigned user.'''
+        msg = self.create_message(
+            self.unicef, 123, self.ann, "Hello", created_on=datetime(2014, 1, 5, 0, 0, tzinfo=pytz.UTC))
+        case = Case.get_or_open(self.unicef, self.user2, msg, 'Hello', self.moh, user_assignee=self.user1)
+
+        self.assertEqual(case.user_assignee, self.user1)
+
+        case_action = CaseAction.objects.get(case=case)
+        self.assertEqual(case_action.user_assignee, self.user1)
+
     def test_search(self):
         d1 = datetime(2014, 1, 9, 0, 0, tzinfo=pytz.UTC)
         d2 = datetime(2014, 1, 10, 0, 0, tzinfo=pytz.UTC)
@@ -530,6 +542,7 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(action.case, self.case)
         self.assertEqual(action.action, CaseAction.REASSIGN)
         self.assertEqual(action.created_by, self.user1)
+        self.assertEqual(action.user_assignee, self.user3)
 
         self.case.refresh_from_db()
         self.assertEqual(self.case.assignee, self.who)
@@ -715,8 +728,8 @@ class CaseCRUDLTest(BaseCasesTest):
 
         # create and open case
         msg1 = self.create_message(self.unicef, 101, self.ann, "What is AIDS?", [self.aids], created_on=d1)
-        case = self.create_case(self.unicef, self.ann, self.moh, msg1)
-        CaseAction.create(case, self.user1, CaseAction.OPEN, assignee=self.moh)
+        case = self.create_case(self.unicef, self.ann, self.moh, msg1, user_assignee=self.user1)
+        CaseAction.create(case, self.user1, CaseAction.OPEN, assignee=self.moh, user_assignee=self.user1)
 
         # backend has a message in the case time window that we don't have locally
         remote_message1 = Outgoing(backend_broadcast_id=102, contact=self.ann, text="Non casepro message...",
@@ -736,6 +749,8 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(response.json['results'][0]['type'], 'I')
         self.assertEqual(response.json['results'][0]['item']['text'], "What is AIDS?")
         self.assertEqual(response.json['results'][0]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
+        self.assertEqual(
+            response.json['results'][0]['item']['case']['user_assignee'], {'id': self.user1.pk, 'name': "Evan"})
         self.assertEqual(response.json['results'][1]['type'], 'O')
         self.assertEqual(response.json['results'][1]['item']['text'], "Non casepro message...")
         self.assertEqual(response.json['results'][1]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -90,6 +90,8 @@
                 opened this case and assigned it to
                 %a{ ng-href:"/partner/read/[[ event.item.assignee.id ]]/" }
                   [[ event.item.assignee.name ]]
+                %a{ ng-href:"/user/read/[[ event.item.user_assignee.id ]]/", ng-if:"event.item.user_assignee" }
+                  ([[ event.item.user_assignee.name ]])
 
               %span{ ng-if:'event.item.action == "S"' }
                 changed the summary
@@ -111,6 +113,8 @@
                 re-assigned this case to
                 %a{ ng-href:"/partner/read/[[ event.item.assignee.id ]]/" }
                   [[ event.item.assignee.name ]]
+                %a{ ng-href:"/user/read/[[ event.item.user_assignee.id ]]/", ng-if:"event.item.user_assignee" }
+                  ([[ event.item.user_assignee.name ]])
 
               %span{ ng-if:'event.item.action == "C"' }
                 closed this case


### PR DESCRIPTION
Currently, the case notes for assignment and reassignment only show the partner, we need to change this to show both the partner and the user, if the case was assigned/reassigned to both a partner and a user.