### PR TITLE
Have assigned user appear in same string in case list

### DIFF
--- a/templates/cases/inbox_cases.haml
+++ b/templates/cases/inbox_cases.haml
@@ -25,7 +25,7 @@
         .case-time
           [[ item.opened_on | autodate ]]
         .case-text
-          %span.label-containe{ ng-if:"!item.user_assignee.name" }
+          %span.label-container{ ng-if:"!item.user_assignee.name" }
             %span.label.label-warning
               [[ item.assignee.name ]]
             &nbsp;

--- a/templates/cases/inbox_cases.haml
+++ b/templates/cases/inbox_cases.haml
@@ -25,13 +25,13 @@
         .case-time
           [[ item.opened_on | autodate ]]
         .case-text
-          %span.label-container
+          %span.label-containe{ ng-if:"!item.user_assignee.name" }
             %span.label.label-warning
               [[ item.assignee.name ]]
             &nbsp;
           %span.label-container{ ng-if:"item.user_assignee.name" }
             %span.label.label-warning
-              [[ item.user_assignee.name ]]
+              [[ item.assignee.name ]] ([[ item.user_assignee.name ]])
             &nbsp;
           %span.label-container{ ng-repeat:"label in filterDisplayLabels(item.labels)" }
             %span.label.label-success

--- a/templates/cases/inbox_cases.haml
+++ b/templates/cases/inbox_cases.haml
@@ -25,11 +25,11 @@
         .case-time
           [[ item.opened_on | autodate ]]
         .case-text
-          %span.label-container{ ng-if:"!item.user_assignee.name" }
+          %span.label-container{ ng-if:"!item.user_assignee" }
             %span.label.label-warning
               [[ item.assignee.name ]]
             &nbsp;
-          %span.label-container{ ng-if:"item.user_assignee.name" }
+          %span.label-container{ ng-if:"item.user_assignee" }
             %span.label.label-warning
               [[ item.assignee.name ]] ([[ item.user_assignee.name ]])
             &nbsp;


### PR DESCRIPTION
Currently, the partner and user are shown in two separate labels in the case list. The suggestion is to have it appear as `Partner (User)` in a single label.