### PR TITLE
Feature/issue 73 automatically reassign case after timeout

### DIFF
--- a/casepro/cases/migrations/0043_case_last_assignee.py
+++ b/casepro/cases/migrations/0043_case_last_assignee.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('cases', '0042_auto_20160812_1612'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='case',
+            name='last_assignee',
+            field=models.ForeignKey(related_name='previously_assigned_cases', to='cases.Partner', null=True),
+        ),
+        migrations.AddField(
+            model_name='case',
+            name='last_reassigned_on',
+            field=models.DateTimeField(help_text='When this case was last reassigned', null=True),
+        ),
+        migrations.AddField(
+            model_name='case',
+            name='last_user_assignee',
+            field=models.ForeignKey(related_name='previously_assigned_cases', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -477,7 +477,6 @@ class Case(models.Model):
         else:
             return False
 
-
     def as_json(self, full=True):
         if full:
             return {

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -453,6 +453,19 @@ class Case(models.Model):
     def is_closed(self):
         return self.closed_on is not None
 
+    @property
+    def has_passed_response_time(self):
+        response_required_in = getattr(settings, 'SITE_CASE_RESPONSE_REQUIRED_TIME', None)
+        if response_required_in is None:
+            return False
+
+        minutes_since_reassigned = (now() - self.last_reassigned_on).total_seconds() // 60
+        if minutes_since_reassigned > response_required_in:
+            return True
+        else:
+            return False
+
+
     def as_json(self, full=True):
         if full:
             return {

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -472,10 +472,7 @@ class Case(models.Model):
             return False
 
         minutes_since_reassigned = (now() - self.last_reassigned_on).total_seconds() // 60
-        if minutes_since_reassigned > response_required_in:
-            return True
-        else:
-            return False
+        return minutes_since_reassigned > response_required_in
 
     def as_json(self, full=True):
         if full:

--- a/casepro/cases/tasks.py
+++ b/casepro/cases/tasks.py
@@ -31,7 +31,7 @@ def get_all_cases_passed_response_time():
 
 @shared_task(ignore_result=True)
 def reassign_case(case_id):
-    from .models import Case, CaseAction
+    from .models import Case, CaseAction, SystemUser
     try:
         case = Case.objects.get(pk=case_id)
     except Case.DoesNotExist:
@@ -48,5 +48,6 @@ def reassign_case(case_id):
         # assignment will just keep flipping back and forth
         return
 
+    system_user = SystemUser.get_or_create()
     note = _("This case's required response time as passed and therefor has been re-assigned")
-    case.reassign(None, case.last_assignee, note=note, user_assignee=case.last_user_assignee)
+    case.reassign(system_user, case.last_assignee, note=note, user_assignee=case.last_user_assignee)

--- a/casepro/cases/tasks.py
+++ b/casepro/cases/tasks.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
-from celery import shared_task
+from celery import shared_task, group
 from celery.utils.log import get_task_logger
+from django.utils.translation import ugettext_lazy as _
 
 logger = get_task_logger(__name__)
 
@@ -13,3 +14,29 @@ def case_export(export_id):
     logger.info("Starting case export #%d..." % export_id)
 
     CaseExport.objects.get(pk=export_id).do_export()
+
+
+@shared_task(ignore_result=True)
+def get_all_cases_passed_response_time():
+    from .models import Case
+    cases = Case.get_all_passed_response_time()
+    tasks = []
+    for case in cases:
+        tasks.append(reassign_case.s(case.pk))
+
+    if tasks:
+        group_task = group(tasks)
+        group_task.apply_async()
+
+
+@shared_task(ignore_result=True)
+def reassign_case(case_id):
+    from .models import Case
+    try:
+        case = Case.objects.get(pk=case_id)
+    except Case.DoesNotExist:
+        logger.warn("Could not load case #%d for re-assignment" % case_id)
+        return
+
+    note = _("This case's required response time as passed and therefor has been re-assigned")
+    case.reassign(None, case.last_assignee, note=note, user_assignee=case.last_user_assignee)

--- a/casepro/cases/tasks.py
+++ b/casepro/cases/tasks.py
@@ -43,7 +43,7 @@ def reassign_case(case_id):
         return
 
     action = case.actions.filter(action=CaseAction.REASSIGN).latest('created_on')
-    if action.created_by is None:
+    if isinstance(action.created_by, SystemUser):
         # The last time this case was reassigned was by the system, we should do nothing now, otherwise the
         # assignment will just keep flipping back and forth
         return

--- a/casepro/cases/tasks.py
+++ b/casepro/cases/tasks.py
@@ -38,5 +38,9 @@ def reassign_case(case_id):
         logger.warn("Could not load case #%d for re-assignment" % case_id)
         return
 
+    if not case.has_passed_response_time:
+        # the case has been reassigned more recently that our expected window, do nothing
+        return
+
     note = _("This case's required response time as passed and therefor has been re-assigned")
     case.reassign(None, case.last_assignee, note=note, user_assignee=case.last_user_assignee)

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -299,8 +299,6 @@ class CaseTest(BaseCasesTest):
 
         msg1 = self.create_message(self.unicef, 123, self.ann, "Hello 1", [self.aids])
         msg2 = self.create_message(self.unicef, 234, bob, "Hello 2", [self.aids, self.pregnancy])
-        msg3 = self.create_message(self.unicef, 345, cat, "Hello 3", [self.pregnancy])
-        msg4 = self.create_message(self.nyaruka, 456, nic, "Hello 4", [self.code])
 
         case1 = self.create_case(self.unicef, self.ann, self.moh, msg1, [self.aids])
         case2 = self.create_case(self.unicef, bob, self.who, msg2, [self.aids, self.pregnancy])

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -1269,13 +1269,9 @@ class TasksTest(BaseCasesTest):
 
         msg1 = self.create_message(self.unicef, 123, self.ann, "Hello 1", [self.aids])
         msg2 = self.create_message(self.unicef, 234, bob, "Hello 2", [self.aids, self.pregnancy])
-        msg3 = self.create_message(self.unicef, 345, cat, "Hello 3", [self.pregnancy])
-        msg4 = self.create_message(self.nyaruka, 456, nic, "Hello 4", [self.code])
 
         case1 = self.create_case(self.unicef, self.ann, self.moh, msg1, [self.aids])
         case2 = self.create_case(self.unicef, bob, self.who, msg2, [self.aids, self.pregnancy])
-        case3 = self.create_case(self.unicef, cat, self.who, msg3, [self.pregnancy])
-        case4 = self.create_case(self.nyaruka, nic, self.klab, msg4, [self.code])
 
         case1.reassign(self.user1, self.who)
         # manually adjust the reassigned date to an expired date
@@ -1286,7 +1282,7 @@ class TasksTest(BaseCasesTest):
         self.assertEqual(case1.assignee, self.moh)
 
         # don't reassign a case if it hasn't passed the expected window
-        case2.reassign(self.user1, self.moh)
+        case2.reassign(self.user3, self.moh)
         reassign_case(case2.pk)
         case2.refresh_from_db()
         self.assertEqual(case1.assignee, self.moh)

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -294,8 +294,6 @@ class CaseTest(BaseCasesTest):
 
     def test_get_all_passed_response_time(self):
         bob = self.create_contact(self.unicef, 'C-002', "Bob")
-        cat = self.create_contact(self.unicef, 'C-003', "Cat")
-        nic = self.create_contact(self.nyaruka, 'C-104', "Nic")
 
         msg1 = self.create_message(self.unicef, 123, self.ann, "Hello 1", [self.aids])
         msg2 = self.create_message(self.unicef, 234, bob, "Hello 2", [self.aids, self.pregnancy])
@@ -578,6 +576,9 @@ class CaseCRUDLTest(BaseCasesTest):
         self.case.refresh_from_db()
         self.assertEqual(self.case.assignee, self.who)
         self.assertEqual(self.case.user_assignee, self.user3)
+        self.assertIsNotNone(self.case.last_reassigned_on)
+        self.assertEqual(self.case.last_assignee, self.moh)
+        self.assertEqual(self.case.last_user_assignee, self.user1)
 
         # only user from assigned partner can re-assign
         response = self.url_post_json('unicef', url, {'assignee': self.moh.pk})

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -1263,9 +1263,19 @@ class TasksTest(BaseCasesTest):
 
 
     def test_reassign_case(self):
-        msg1 = self.create_message(self.unicef, 123, self.ann, "Hello 1", [self.aids])
-        case1 = self.create_case(self.unicef, self.ann, self.moh, msg1, [self.aids])
+        bob = self.create_contact(self.unicef, 'C-002', "Bob")
+        cat = self.create_contact(self.unicef, 'C-003', "Cat")
+        nic = self.create_contact(self.nyaruka, 'C-104', "Nic")
 
+        msg1 = self.create_message(self.unicef, 123, self.ann, "Hello 1", [self.aids])
+        msg2 = self.create_message(self.unicef, 234, bob, "Hello 2", [self.aids, self.pregnancy])
+        msg3 = self.create_message(self.unicef, 345, cat, "Hello 3", [self.pregnancy])
+        msg4 = self.create_message(self.nyaruka, 456, nic, "Hello 4", [self.code])
+
+        case1 = self.create_case(self.unicef, self.ann, self.moh, msg1, [self.aids])
+        case2 = self.create_case(self.unicef, bob, self.who, msg2, [self.aids, self.pregnancy])
+        case3 = self.create_case(self.unicef, cat, self.who, msg3, [self.pregnancy])
+        case4 = self.create_case(self.nyaruka, nic, self.klab, msg4, [self.code])
 
         case1.reassign(self.user1, self.who)
         # manually adjust the reassigned date to an expired date
@@ -1273,4 +1283,10 @@ class TasksTest(BaseCasesTest):
         case1.save()
         reassign_case(case1.pk)
         case1.refresh_from_db()
+        self.assertEqual(case1.assignee, self.moh)
+
+        # don't reassign a case if it hasn't passed the expected window
+        case2.reassign(self.user1, self.moh)
+        reassign_case(case2.pk)
+        case2.refresh_from_db()
         self.assertEqual(case1.assignee, self.moh)

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -1334,6 +1334,7 @@ class TasksTest(BaseCasesTest):
                                        fields={'age': "34"},
                                        groups=[self.females, self.reporters, self.registered])
 
+    @override_settings(SITE_CASE_RESPONSE_REQUIRED_TIME=1440)
     def test_reassign_case(self):
         bob = self.create_contact(self.unicef, 'C-002', "Bob")
 

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -304,8 +304,6 @@ class CaseTest(BaseCasesTest):
 
         case1 = self.create_case(self.unicef, self.ann, self.moh, msg1, [self.aids])
         case2 = self.create_case(self.unicef, bob, self.who, msg2, [self.aids, self.pregnancy])
-        case3 = self.create_case(self.unicef, cat, self.who, msg3, [self.pregnancy])
-        case4 = self.create_case(self.nyaruka, nic, self.klab, msg4, [self.code])
 
         # test with no last_reassigned_on value set
         self.assertEqual(set(Case.get_all_passed_response_time()), set())
@@ -1329,7 +1327,6 @@ class InternalViewsTest(BaseCasesTest):
             self.assertEqual(response.status_code, 500)
 
 
-
 class TasksTest(BaseCasesTest):
     def setUp(self):
         super(TasksTest, self).setUp()
@@ -1338,11 +1335,8 @@ class TasksTest(BaseCasesTest):
                                        fields={'age': "34"},
                                        groups=[self.females, self.reporters, self.registered])
 
-
     def test_reassign_case(self):
         bob = self.create_contact(self.unicef, 'C-002', "Bob")
-        cat = self.create_contact(self.unicef, 'C-003', "Cat")
-        nic = self.create_contact(self.nyaruka, 'C-104', "Nic")
 
         msg1 = self.create_message(self.unicef, 123, self.ann, "Hello 1", [self.aids])
         msg2 = self.create_message(self.unicef, 234, bob, "Hello 2", [self.aids, self.pregnancy])

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -292,6 +292,7 @@ class CaseTest(BaseCasesTest):
         self.assertEqual(set(Case.get_closed(self.unicef)), {case2})
         self.assertEqual(set(Case.get_closed(self.unicef, user=self.user1, label=self.pregnancy)), {case2})
 
+    @override_settings(SITE_CASE_RESPONSE_REQUIRED_TIME=1440)
     def test_get_all_passed_response_time(self):
         bob = self.create_contact(self.unicef, 'C-002', "Bob")
 

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -494,6 +494,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'casepro.profiles.tasks.send_notifications',
         'schedule': timedelta(minutes=1),
     },
+    'reassign-case-passed-response-time': {
+        'task': 'casepro.cases.tasks.get_all_cases_passed_response_time',
+        'schedule': timedelta(minutes=60),
+    },
 }
 
 CELERY_TIMEZONE = 'UTC'

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -57,7 +57,7 @@ SITE_ORGS_STORAGE_ROOT = 'orgs'
 SITE_EXTERNAL_CONTACT_URL = 'http://localhost:8001/contact/read/%s/'
 SITE_BACKEND = 'casepro.backend.NoopBackend'
 SITE_ANON_CONTACTS = False
-SITE_CASE_RESPONSE_REQUIRED_TIME = 1440  # 24 hours in minutes
+SITE_CASE_RESPONSE_REQUIRED_TIME = None  # specified in minutes, None to disable
 
 # junebug configuration
 JUNEBUG_API_ROOT = 'http://localhost:8080/'

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -57,6 +57,7 @@ SITE_ORGS_STORAGE_ROOT = 'orgs'
 SITE_EXTERNAL_CONTACT_URL = 'http://localhost:8001/contact/read/%s/'
 SITE_BACKEND = 'casepro.backend.NoopBackend'
 SITE_ANON_CONTACTS = False
+SITE_CASE_RESPONSE_REQUIRED_TIME = 1440  # 24 hours in minutes
 
 # junebug configuration
 JUNEBUG_API_ROOT = 'http://localhost:8080/'


### PR DESCRIPTION
As detailed in #73 this creates a periodic task (every 60 minutes) that looks for cases that are still open after a set amount of time and re-assigns them back to their previous assignee. 