### PR TITLE
Have cases view not rely on initial_message

### DIFF
--- a/casepro/cases/migrations/0046_auto_20160816_1421.py
+++ b/casepro/cases/migrations/0046_auto_20160816_1421.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cases', '0045_case_last_assignee'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='case',
+            name='initial_message',
+            field=models.OneToOneField(related_name='initial_case', null=True, to='msgs.Message'),
+        ),
+    ]

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -157,7 +157,7 @@ class Case(models.Model):
 
     contact = models.ForeignKey(Contact, related_name='cases')
 
-    initial_message = models.OneToOneField(Message, related_name='initial_case')
+    initial_message = models.OneToOneField(Message, null=True, related_name='initial_case')
 
     summary = models.CharField(verbose_name=_("Summary"), max_length=255)
 

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -891,6 +891,19 @@ class CaseCRUDLTest(BaseCasesTest):
         mock_fetch_contact_messages.assert_called_once_with(self.unicef, self.ann, d1, case.closed_on)
         mock_fetch_contact_messages.reset_mock()
 
+    def test_timeline_no_initial_message(self):
+        '''If a case has no initial message, the timeline should start from the datetime it was opened.'''
+        case = self.create_case(self.unicef, self.ann, self.moh, message=None, user_assignee=self.user1)
+        caseaction = CaseAction.create(case, self.user1, CaseAction.OPEN, assignee=self.moh, user_assignee=self.user1)
+
+        timeline_url = reverse('cases.case_timeline', args=[case.pk])
+        self.login(self.user1)
+        response = self.url_get('unicef', '%s?after=' % timeline_url)
+
+        [case_open] = response.json['results']
+        self.assertEqual(case_open['item']['action'], CaseAction.OPEN)
+        self.assertEqual(case_open['item']['id'], caseaction.pk)
+
     def test_search(self):
         url = reverse('cases.case_search')
 

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -268,7 +268,10 @@ class CaseCRUDL(SmartCRUDL):
                 merge_from_backend = False
             else:
                 # this is the initial request for the complete timeline
-                after = self.object.initial_message.created_on
+                if self.object.initial_message is not None:
+                    after = self.object.initial_message.created_on
+                else:
+                    after = self.object.opened_on
                 merge_from_backend = True
 
             if self.object.closed_on:

--- a/casepro/test.py
+++ b/casepro/test.py
@@ -137,8 +137,9 @@ class BaseCasesTest(DashTest):
             case.opened_on = kwargs['opened_on']
             case.save(update_fields=('opened_on',))
 
-        message.case = case
-        message.save(update_fields=('case',))
+        if message:
+            message.case = case
+            message.save(update_fields=('case',))
 
         return case
 


### PR DESCRIPTION
Currently, to generate the timeline for the case detail view, it relies on there being an `initial_message` attribute with a message attached to find the beginning of the timeline. If there is no `initial_message`, it currently breaks. This behaviour should be changed to setting the start date to the case creation date, if the `initial_message` is `None`.