### PR TITLE
Have case exports not assume initial_message

### DIFF
--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -604,14 +604,15 @@ class CaseExport(BaseSearchExport):
                 row = 1
 
             values = [
-                item.initial_message.created_on,
+                item.initial_message.created_on if item.initial_message else '',
                 item.opened_on,
                 item.closed_on,
                 item.assignee.name,
                 ', '.join([l.name for l in item.labels.all()]),
                 item.summary,
                 item.outgoing_count,
-                item.incoming_count - 1,  # subtract 1 for the initial messages
+                # subtract 1 for the initial messages
+                item.incoming_count - 1 if item.initial_message else item.incoming_count,
                 item.contact.uuid
             ]
 

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -1050,7 +1050,7 @@ class CaseExportCRUDLTest(BaseCasesTest):
 
     @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, BROKER_BACKEND='memory')
     def test_create_with_no_initial_message(self):
-        '''When a case is exported with initial_message=None, the field should be a blank string.'''
+        """When a case is exported with initial_message=None, the field should be a blank string."""
         ann = self.create_contact(self.unicef, "C-001", "Ann")
         case = self.create_case(self.unicef, ann, self.moh, None, [self.aids], summary="What is HIV?")
 


### PR DESCRIPTION
Currently, the exports assume that there is an `initial_message` field that is not `None`. This should be changed so that it still works when `initial_message = None`.