### PR TITLE
Add push_contact function to the backend

### DIFF
--- a/casepro/backend/__init__.py
+++ b/casepro/backend/__init__.py
@@ -93,6 +93,15 @@ class BaseBackend(object):
         """
 
     @abstractmethod
+    def push_contact(self, org, contact):
+        """
+        Pushes a new or updated contact
+
+        :param org: the org
+        :param contact: The contact to update/create
+        """
+
+    @abstractmethod
     def add_to_group(self, org, contact, group):
         """
         Adds the given contact to a group

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -282,6 +282,15 @@ class JunebugBackend(BaseBackend):
         for message in outgoing:
             self.message_sender.send_message(message)
 
+    def push_contact(self, org, contact):
+        """
+        Pushes a new or updated contact
+
+        :param org: the org
+        :param contact: The contact to update/create
+        """
+        return
+
     def add_to_group(self, org, contact, group):
         """
         Adds the given contact to a group

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -280,6 +280,9 @@ class RapidProBackend(BaseBackend):
                 msg.backend_broadcast_id = broadcast.id
                 msg.save(update_fields=('backend_broadcast_id',))
 
+    def push_contact(self, org, contact):
+        return
+
     def add_to_group(self, org, contact, group):
         client = self._get_client(org, 1)
         client.add_contacts([contact.uuid], group_uuid=group.uuid)


### PR DESCRIPTION
We want to be allow Casepro to create contacts. The first step to this is to add a `push_contact` function to the backend, to allow contacts that are created on the casepro side to be created on the backend at the same time.