### PR TITLE
Change contact's uuid field to be nullable

### DIFF
--- a/casepro/contacts/migrations/0024_auto_20160822_1224.py
+++ b/casepro/contacts/migrations/0024_auto_20160822_1224.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0023_contact_urns'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='uuid',
+            field=models.CharField(max_length=36, unique=True, null=True),
+        ),
+    ]

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -137,7 +137,7 @@ class Contact(models.Model):
 
     org = models.ForeignKey(Org, verbose_name=_("Organization"), related_name="contacts")
 
-    uuid = models.CharField(max_length=36, unique=True)
+    uuid = models.CharField(max_length=36, unique=True, null=True)
 
     name = models.CharField(verbose_name=_("Full name"), max_length=128, null=True, blank=True,
                             help_text=_("The name of this contact"))


### PR DESCRIPTION
We want to be allow Casepro to create contacts. The second step to this is to allow the UUID field on contacts to be nullable. This way, we can create a contact with a `null` UUID field, and have the field be set to the appropriate value when it is pushed to the backend.