### PR TITLE
Implement push_contact for Junebug backend

### DIFF
--- a/casepro/backend/__init__.py
+++ b/casepro/backend/__init__.py
@@ -95,10 +95,10 @@ class BaseBackend(object):
     @abstractmethod
     def push_contact(self, org, contact):
         """
-        Pushes a new or updated contact
+        Pushes a new contact
 
         :param org: the org
-        :param contact: The contact to update/create
+        :param contact: The contact to create
         """
 
     @abstractmethod

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -68,17 +68,20 @@ class IdentityStore(object):
             "%s/api/v1/identities/search/" % (self.base_url),
             params={'details__addresses__%s' % self.address_type: address})
 
-    def create_identity(self, address):
+    def create_identity(self, addresses, name=None, language=None):
+        """Creates an identity on the identity store, given the details of the identity."""
+        address_dict = {}
+        for address in addresses:
+            type_, addr = address.split(':', 1)
+            address_dict[type_] = {addr: {}}
         identity = self.session.post(
             "%s/api/v1/identities/" % (self.base_url,),
             json={
                 'details': {
-                    'addresses': {
-                        self.address_type: {
-                            address: {},
-                        },
-                    },
-                    'default_addr_type': "msisdn",
+                    'addresses': address_dict,
+                    'default_addr_type': self.address_type,
+                    'name': name,
+                    'language': language,
                 },
             }
         )
@@ -440,7 +443,7 @@ def received_junebug_message(request):
     try:
         identity = identities.next()
     except StopIteration:
-        identity = identity_store.create_identity(data.get('from'))
+        identity = identity_store.create_identity(['%s:%s' % (settings.IDENTITY_ADDRESS_TYPE, data.get('from'))])
     contact = Contact.get_or_create(request.org, identity.get('id'))
 
     message_id = uuid_to_int(data.get('message_id'))

--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -656,6 +656,8 @@ class JunebugInboundViewTest(BaseCasesTest):
                 },
             },
             'default_addr_type': "msisdn",
+            'name': None,
+            'language': None,
         })
         headers = {'Content-Type': "application/json"}
         return (201, headers, json.dumps(self.create_identity_obj()))
@@ -1193,6 +1195,8 @@ class IdentityStoreTest(BaseCasesTest):
                 },
             },
             'default_addr_type': "msisdn",
+            'name': "Test identity",
+            'language': "eng",
         })
         headers = {'Content-Type': "application/json"}
         return (201, headers, json.dumps(self.create_identity_obj()))
@@ -1210,7 +1214,7 @@ class IdentityStoreTest(BaseCasesTest):
             responses.POST, url, callback=self.create_identity_callback, match_querystring=True,
             content_type="application/json")
 
-        identity = identity_store.create_identity("+1234")
+        identity = identity_store.create_identity(["msisdn:+1234"], name="Test identity", language="eng")
         self.assertEqual(identity['details'], {
             'addresses': {
                 'msisdn': {


### PR DESCRIPTION
We want to be allow Casepro to create contacts. Once we have completed the two steps of adding a `push_contact` function to the backend, and making the UUID field on a contact nullable, we can now implement the `push_contact` function for the Junebug backend.