### PR TITLE
limit users for partners

### DIFF
--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -404,6 +404,8 @@ GROUP_PERMISSIONS = {
         'profiles.profile_user_update',
         'profiles.profile_user_read',
         'profiles.profile_user_list',
+
+        'statistics.dailycountexport.*',
     ),
     "Viewers": (  # Partner users: Data Analysts
         'orgs.org_inbox',

--- a/casepro/statistics/models.py
+++ b/casepro/statistics/models.py
@@ -257,7 +257,15 @@ class DailyCountExport(BaseExport):
             cases_opened_sheet = book.add_sheet(six.text_type(_("Cases Opened")))
             cases_closed_sheet = book.add_sheet(six.text_type(_("Cases Closed")))
 
-            users = self.org.get_org_users().order_by('pk')
+            if self.created_by.can_administer(self.org):
+                users = self.org.get_org_users().order_by('pk')
+            elif self.created_by.can_manage(self.org):
+                users = set([])
+                for partner in Partner.objects.filter(org=self.org):
+                    for user in partner.get_users():
+                        users.add(user)
+            else:
+                users = [user]
 
             replies_totals_by_user = {}
             cases_opened_by_user = {}

--- a/casepro/statistics/models.py
+++ b/casepro/statistics/models.py
@@ -13,6 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from casepro.cases.models import Partner
 from casepro.msgs.models import Label
+from casepro.profiles.models import ROLE_ADMIN, ROLE_MANAGER
 from casepro.utils import date_range
 from casepro.utils.export import BaseExport
 
@@ -257,9 +258,9 @@ class DailyCountExport(BaseExport):
             cases_opened_sheet = book.add_sheet(six.text_type(_("Cases Opened")))
             cases_closed_sheet = book.add_sheet(six.text_type(_("Cases Closed")))
 
-            if self.created_by.can_administer(self.org):
+            if self.created_by.get_role(self.org) == ROLE_ADMIN:
                 users = self.org.get_org_users().order_by('pk')
-            elif self.created_by.can_manage(self.org):
+            elif self.created_by.get_role(self.org) == ROLE_MANAGER:
                 users = set([])
                 for partner in Partner.objects.filter(org=self.org):
                     for user in partner.get_users():

--- a/casepro/statistics/models.py
+++ b/casepro/statistics/models.py
@@ -262,7 +262,8 @@ class DailyCountExport(BaseExport):
                 users = self.org.get_org_users().order_by('pk')
             elif self.created_by.get_role(self.org) == ROLE_MANAGER:
                 users = set([])
-                for partner in Partner.objects.filter(org=self.org):
+                partners_for_user = Partner.objects.filter(org=self.org, users__pk=self.created_by.pk)
+                for partner in partners_for_user:
                     for user in partner.get_users():
                         users.add(user)
             else:

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -370,16 +370,16 @@ class DailyCountExportTest(BaseStatsTest):
         # Should only return rows for MOH partner users
         self.assertEqual(replies_sheet.nrows, 32)
         self.assertExcelRow(replies_sheet, 0, ['Date', 'Evan', 'Rick'])
-        self.assertExcelRow(replies_sheet, 1, [d1, 0, 0, 0], tz=tz)
-        self.assertExcelRow(replies_sheet, 15, [d2, 0, 0, 0], tz=tz)
+        self.assertExcelRow(replies_sheet, 1, [d1, 0, 0], tz=tz)
+        self.assertExcelRow(replies_sheet, 15, [d2, 0, 0], tz=tz)
 
         self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Evan', 'Rick'])
-        self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 0, 0], tz=tz)
-        self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 0], tz=tz)
+        self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 0], tz=tz)
 
         self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Evan', 'Rick'])
-        self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0, 0], tz=tz)
-        self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0], tz=tz)
+        self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0], tz=tz)
 
 
 class ChartsTest(BaseStatsTest):

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -359,8 +359,7 @@ class DailyCountExportTest(BaseStatsTest):
         self.new_outgoing(self.user3, d2, 1)  # Jan 15th
 
         # logging in as user1, who's a manager for UNICEF not Nyaruka
-        self.login(self.user1)
-
+        self.client.login(username=self.user1.username, password=self.user1.email)
         response = self.url_post_json('unicef', url, {'type': 'U', 'after': "2016-01-01", 'before': "2016-01-31"})
         self.assertEqual(response.status_code, 200)
 

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -355,8 +355,8 @@ class DailyCountExportTest(BaseStatsTest):
             [msg] = self.new_messages(d2, 1)
             Case.get_or_open(self.nyaruka, self.user4, msg, 'summary', self.moh)
 
-        self.new_outgoing(self.user1, d1, 1)  # Jan 1st
-        self.new_outgoing(self.user3, d2, 1)  # Jan 15th
+        self.new_outgoing(self.user4, d1, 1)  # Jan 1st
+        self.new_outgoing(self.user4, d2, 1)  # Jan 15th
 
         # logging in as user1, who's a manager for UNICEF not Nyaruka
         self.login(self.user1)
@@ -368,17 +368,17 @@ class DailyCountExportTest(BaseStatsTest):
         (replies_sheet, cases_opened_sheet, cases_closed_sheet) = workbook.sheets()
 
         self.assertEqual(replies_sheet.nrows, 32)
-        self.assertExcelRow(replies_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
-        self.assertExcelRow(replies_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)
-        self.assertExcelRow(replies_sheet, 15, [d2, 0, 0, 0, 0], tz=tz)
+        self.assertExcelRow(replies_sheet, 0, ['Date', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(replies_sheet, 1, [d1, 0, 0, 0], tz=tz)
+        self.assertExcelRow(replies_sheet, 15, [d2, 0, 0, 0], tz=tz)
 
-        self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
-        self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)
-        self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 0, 0], tz=tz)
 
-        self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
-        self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)
-        self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0, 0], tz=tz)
 
 
 class ChartsTest(BaseStatsTest):

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -358,7 +358,7 @@ class DailyCountExportTest(BaseStatsTest):
         self.new_outgoing(self.user4, d1, 1)  # Jan 1st
         self.new_outgoing(self.user4, d2, 1)  # Jan 15th
 
-        # logging in as user1, who's a manager for UNICEF not Nyaruka
+        # logging in as user1, who's a manager for MOH UNICEF not Nyaruka
         self.login(self.user1)
         response = self.url_post_json('unicef', url, {'type': 'U', 'after': "2016-01-01", 'before': "2016-01-31"})
         self.assertEqual(response.status_code, 200)
@@ -367,16 +367,17 @@ class DailyCountExportTest(BaseStatsTest):
         workbook = self.openWorkbook(export.filename)
         (replies_sheet, cases_opened_sheet, cases_closed_sheet) = workbook.sheets()
 
+        # Should only return rows for MOH partner users
         self.assertEqual(replies_sheet.nrows, 32)
-        self.assertExcelRow(replies_sheet, 0, ['Date', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(replies_sheet, 0, ['Date', 'Evan', 'Rick'])
         self.assertExcelRow(replies_sheet, 1, [d1, 0, 0, 0], tz=tz)
         self.assertExcelRow(replies_sheet, 15, [d2, 0, 0, 0], tz=tz)
 
-        self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Evan', 'Rick'])
         self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 0, 0], tz=tz)
         self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 0, 0], tz=tz)
 
-        self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Evan', 'Rick'])
         self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0, 0], tz=tz)
         self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0, 0], tz=tz)
 

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -295,7 +295,7 @@ class DailyCountExportTest(BaseStatsTest):
         self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0], tz=tz)
 
     @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, BROKER_BACKEND='memory')
-    def test_user_export(self):
+    def test_admin_user_export(self):
         url = reverse('statistics.dailycountexport_create')
 
         tz = pytz.timezone("Africa/Kampala")
@@ -332,6 +332,50 @@ class DailyCountExportTest(BaseStatsTest):
         self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
         self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 1, 0, 0], tz=tz)
         self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 1, 0, 0], tz=tz)
+
+        self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_closed_sheet, 15, [d2, 0, 0, 0, 0], tz=tz)
+
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, BROKER_BACKEND='memory')
+    def test_manager_user_export(self):
+        url = reverse('statistics.dailycountexport_create')
+
+        tz = pytz.timezone("Africa/Kampala")
+        d1 = date(2016, 1, 1)
+        d2 = date(2016, 1, 15)
+
+        # Jan 1st, cases opened by User1 who's part of Nyaruka
+        with patch.object(timezone, 'now', return_value=self.anytime_on_day(d1, tz)):
+            [msg] = self.new_messages(d1, 1)
+            Case.get_or_open(self.nyaruka, self.user4, msg, 'summary', self.moh)
+
+        # Jan 15th
+        with patch.object(timezone, 'now', return_value=self.anytime_on_day(d2, tz)):
+            [msg] = self.new_messages(d2, 1)
+            Case.get_or_open(self.nyaruka, self.user4, msg, 'summary', self.moh)
+
+        self.new_outgoing(self.user1, d1, 1)  # Jan 1st
+        self.new_outgoing(self.user3, d2, 1)  # Jan 15th
+
+        # logging in as user1, who's a manager for UNICEF not Nyaruka
+        self.login(self.user1)
+
+        response = self.url_post_json('unicef', url, {'type': 'U', 'after': "2016-01-01", 'before': "2016-01-31"})
+        self.assertEqual(response.status_code, 200)
+
+        export = DailyCountExport.objects.get()
+        workbook = self.openWorkbook(export.filename)
+        (replies_sheet, cases_opened_sheet, cases_closed_sheet) = workbook.sheets()
+
+        self.assertEqual(replies_sheet.nrows, 32)
+        self.assertExcelRow(replies_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(replies_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)
+        self.assertExcelRow(replies_sheet, 15, [d2, 0, 0, 0, 0], tz=tz)
+
+        self.assertExcelRow(cases_opened_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
+        self.assertExcelRow(cases_opened_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)
+        self.assertExcelRow(cases_opened_sheet, 15, [d2, 0, 0, 0, 0], tz=tz)
 
         self.assertExcelRow(cases_closed_sheet, 0, ['Date', 'Kidus', 'Evan', 'Rick', 'Carol'])
         self.assertExcelRow(cases_closed_sheet, 1, [d1, 0, 0, 0, 0], tz=tz)

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -359,7 +359,7 @@ class DailyCountExportTest(BaseStatsTest):
         self.new_outgoing(self.user3, d2, 1)  # Jan 15th
 
         # logging in as user1, who's a manager for UNICEF not Nyaruka
-        self.client.login(username=self.user1.username, password=self.user1.email)
+        self.login(self.user1)
         response = self.url_post_json('unicef', url, {'type': 'U', 'after': "2016-01-01", 'before': "2016-01-31"})
         self.assertEqual(response.status_code, 200)
 

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -345,7 +345,7 @@ class DailyCountExportTest(BaseStatsTest):
         d1 = date(2016, 1, 1)
         d2 = date(2016, 1, 15)
 
-        # Jan 1st, cases opened by User1 who's part of Nyaruka
+        # Jan 1st, cases opened by User4 who's part of Nyaruka
         with patch.object(timezone, 'now', return_value=self.anytime_on_day(d1, tz)):
             [msg] = self.new_messages(d1, 1)
             Case.get_or_open(self.nyaruka, self.user4, msg, 'summary', self.moh)


### PR DESCRIPTION
When logged in as a manager, only download user stats for the partner.
