### PR TITLE
Add modal for creating case without message

### DIFF
--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -264,6 +264,9 @@ class Case(models.Model):
         any open case for that contact will be returned. If no open cases exist for the contact, a new case will be
         created.
         """
+        if not message and not contact:
+            raise ValueError("Opening a case requires a message or contact")
+
         from casepro.profiles.models import Notification
         r = get_redis_connection()
 

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -362,6 +362,45 @@ class CaseTest(BaseCasesTest):
         case_action = CaseAction.objects.get(case=case)
         self.assertEqual(case_action.user_assignee, self.user1)
 
+    def test_get_open_no_initial_message_new_case(self):
+        """
+        We should be able to create a case with no initial message, but by supplying a contact instead.
+        """
+        case = Case.get_or_open(
+            self.unicef, self.user2, None, 'Hello', self.moh, user_assignee=self.user1, contact=self.ann)
+
+        self.assertEqual(case.contact, self.ann)
+        self.assertEqual(case.assignee, self.moh)
+        self.assertEqual(case.user_assignee, self.user1)
+        self.assertEqual(case.initial_message, None)
+        self.assertEqual(case.is_new, True)
+        self.assertEqual(list(case.watchers.all()), [self.user2])
+
+        [case_action] = list(CaseAction.objects.filter(case=case))
+        self.assertEqual(case_action.action, CaseAction.OPEN)
+        self.assertEqual(case_action.assignee, self.moh)
+        self.assertEqual(case_action.user_assignee, self.user1)
+
+    def test_get_open_no_initial_message_existing_case(self):
+        """
+        When using get_or_open with no initial message, but by supplying a contact, but that contact already has an
+        open case, it should return that case instead of creating a new one.
+        """
+        case1 = Case.get_or_open(
+            self.unicef, self.user2, None, 'Hello', self.moh, user_assignee=self.user1, contact=self.ann)
+        case2 = Case.get_or_open(
+            self.unicef, self.user2, None, 'Hello', self.moh, user_assignee=self.user1, contact=self.ann)
+
+        self.assertEqual(case2.is_new, False)
+        self.assertEqual(case1, case2)
+
+        case1.close(self.user1)
+
+        case3 = Case.get_or_open(
+            self.unicef, self.user2, None, 'Hello', self.moh, user_assignee=self.user1, contact=self.ann)
+        self.assertEqual(case3.is_new, True)
+        self.assertNotEqual(case2, case3)
+
     def test_search(self):
         d1 = datetime(2014, 1, 9, 0, 0, tzinfo=pytz.UTC)
         d2 = datetime(2014, 1, 10, 0, 0, tzinfo=pytz.UTC)

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -550,6 +550,22 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(case.initial_message, None)
         self.assertEqual(case.contact, contact)
 
+    def test_open_no_message_id_new_contact(self):
+        """
+        If a case is opened, and no initial message is supplied, but an URN is supplied instead, and the URN doesn't
+        match any existing users, then a new contact should be created, and the case assigned to that contact.
+        """
+        url = reverse('cases.case_open')
+        self.login(self.admin)
+        response = self.url_post_json('unicef', url, {
+            'message': None, 'summary': "Summary", 'assignee': self.moh.pk, 'user_assignee': self.user1.pk,
+            'urn': "+1234"})
+        self.assertEqual(response.status_code, 200)
+
+        case = Case.objects.get(pk=response.json['id'])
+        self.assertEqual(case.initial_message, None)
+        self.assertEqual(case.contact.urns, ["+1234"])
+
     def test_read(self):
         url = reverse('cases.case_read', args=[self.case.pk])
 

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -84,7 +84,7 @@ class CaseCRUDL(SmartCRUDL):
 
     class Open(OrgPermsMixin, SmartCreateView):
         """
-        JSON endpoint for opening a new case. Takes a message backend id.
+        JSON endpoint for opening a new case. Takes a message backend id, or a URN.
         """
         permission = 'cases.case_create'
 

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -201,10 +201,12 @@ class Contact(models.Model):
     def get_display_name(self):
         """
         Gets the display name of this contact. If name is empty or site uses anonymous contacts, this is generated from
-        the backend UUID.
+        the backend UUID. If no UUID is set for the contact, an empty string is returned.
         """
         if not self.name or getattr(settings, 'SITE_ANON_CONTACTS', False):
-            return self.uuid[:6].upper()
+            if self.uuid:
+                return self.uuid[:6].upper()
+            return ""
         else:
             return self.name
 

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -186,7 +186,7 @@ class Contact(models.Model):
     @classmethod
     def get_or_create_from_urn(cls, org, urn, name=None):
         """
-        Gets an existing contact or creates a stub contact. Used when opening a case without an initial message
+        Gets an existing contact or creates a new contact. Used when opening a case without an initial message
         """
         contact = cls.objects.filter(urns__contains=[urn]).first()
         if not contact:

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -190,7 +190,7 @@ class Contact(models.Model):
         """
         contact = cls.objects.filter(urns__contains=[urn]).first()
         if not contact:
-            contact = cls.objects.create(org=org, name=name, urns=[urn], is_stub=True)
+            contact = cls.objects.create(org=org, name=name, urns=[urn], is_stub=False)
             get_backend().push_contact(org, contact)
         return contact
 

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -544,7 +544,7 @@ describe('controllers:', () ->
         expect(MessageService.bulkFlag).toHaveBeenCalledWith([test.msg2], true)
       )
 
-      it('onCaseWithoutMessage', () ->
+      it('onCaseWithoutMessage existing case', () ->
         createCaseModal = spyOnPromise($q, $scope, ModalService, 'create_case')
         openCase = spyOnPromise($q, $scope, CaseService, 'open')
         redirect = spyOnPromise($q, $scope, UtilsService, 'navigate')
@@ -557,6 +557,21 @@ describe('controllers:', () ->
 
         openCase.resolve({is_new: false, id: 7})
         expect(UtilsService.navigate).toHaveBeenCalledWith('case/read/7/?alert=open_found_existing')
+      )
+
+      it('onCaseWithoutMessage no existing case', () ->
+        createCaseModal = spyOnPromise($q, $scope, ModalService, 'create_case')
+        openCase = spyOnPromise($q, $scope, CaseService, 'open')
+        redirect = spyOnPromise($q, $scope, UtilsService, 'navigate')
+
+        $scope.onCaseWithoutMessage()
+        expect(ModalService.create_case).toHaveBeenCalledWith({title: 'Create case'})
+
+        createCaseModal.resolve({text: 'test summary', partner: 2, user: 3, urn: 'tel:123'})
+        expect(CaseService.open).toHaveBeenCalledWith(null, 'test summary', 2, 3, 'tel:123')
+
+        openCase.resolve({is_new: true, id: 7})
+        expect(UtilsService.navigate).toHaveBeenCalledWith('case/read/7/')
       )
     )
 

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -241,18 +241,20 @@ describe('controllers:', () ->
     CaseService = null
     PartnerService = null
     UserService = null
+    ModalService = null
 
     $inboxScope = null
     $scope = null
     serverTime = 1464775597109  # ~ Jun 1st 2016 10:06:37 UTC
 
     beforeEach(() ->
-      inject((_MessageService_, _OutgoingService_, _CaseService_, _PartnerService_, _UserService_) ->
+      inject((_MessageService_, _OutgoingService_, _CaseService_, _PartnerService_, _UserService_, _ModalService_) ->
         MessageService = _MessageService_
         OutgoingService = _OutgoingService_
         CaseService = _CaseService_
         PartnerService = _PartnerService_
         UserService = _UserService_
+        ModalService = _ModalService_
       )
 
       $window.contextData = {user: test.user1, partners: [], labels: [test.tea, test.coffee], groups: []}
@@ -540,6 +542,21 @@ describe('controllers:', () ->
         bulkFlag.resolve()
 
         expect(MessageService.bulkFlag).toHaveBeenCalledWith([test.msg2], true)
+      )
+
+      it('onCaseWithoutMessage', () ->
+        createCaseModal = spyOnPromise($q, $scope, ModalService, 'create_case')
+        openCase = spyOnPromise($q, $scope, CaseService, 'open')
+        redirect = spyOnPromise($q, $scope, UtilsService, 'navigate')
+
+        $scope.onCaseWithoutMessage()
+        expect(ModalService.create_case).toHaveBeenCalledWith({title: 'Create case'})
+
+        createCaseModal.resolve({text: 'test summary', partner: 2, user: 3, urn: 'tel:123'})
+        expect(CaseService.open).toHaveBeenCalledWith(null, 'test summary', 2, 3, 'tel:123')
+
+        openCase.resolve({is_new: false, id: 7})
+        expect(UtilsService.navigate).toHaveBeenCalledWith('case/read/7/?alert=open_found_existing')
       )
     )
 

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -731,7 +731,7 @@ describe('services:', () ->
             prompt: 'Bar?'
           })
           .then(-> fulfilled = true)
-
+          
           $rootScope.$apply()
           expect(fulfilled).toBe(false)
 
@@ -816,6 +816,63 @@ describe('services:', () ->
           expect(rejected).toBe(true)
         )
       )
+    )
+
+    describe('create_case', () ->
+        it('should draw the modal', () ->
+          $httpBackend.expectGET('/partner/?with_activity=false')
+            .respond([])
+          ModalService.create_case({
+            title: 'Foo',
+          })
+
+          $rootScope.$apply()
+
+          expect(document.querySelector('.modal-title').textContent)
+            .toMatch('Foo')
+        )
+
+        it('should fulfill if the modal is accepted', () ->
+          fulfilled = false
+
+          $httpBackend.expectGET('/partner/?with_activity=false')
+            .respond([])
+          ModalService.create_case({
+            title: 'Foo',
+            initial: 'Bar',
+            initial_urn: '123',
+          })
+          .then(-> fulfilled = true)
+
+          $rootScope.$apply()
+          expect(fulfilled).toBe(false)
+
+          angular.element(document.querySelector('.btn-modal-accept'))
+            .triggerHandler('click')
+
+          $rootScope.$apply()
+          expect(fulfilled).toBe(true)
+        )
+
+        it('should reject if the modal is cancelled', () ->
+          rejected = false
+
+          ModalService.confirm({
+            title: 'Foo',
+            initial: 'Bar',
+            initial_urn: '123',
+          })
+          .catch(-> rejected = true)
+
+          $rootScope.$apply()
+          expect(rejected).toBe(false)
+
+          angular.element(document.querySelector('.btn-modal-cancel'))
+            .triggerHandler('click')
+
+          $rootScope.$apply()
+          expect(rejected).toBe(true)
+        )
     )
   )
 
@@ -925,4 +982,5 @@ describe('services:', () ->
       )
     )
   )
+
 )

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -839,14 +839,14 @@ describe('services:', () ->
             .respond([])
           ModalService.create_case({
             title: 'Foo',
-            initial: 'Bar',
-            initial_urn: '123',
           })
           .then(-> fulfilled = true)
 
           $rootScope.$apply()
           expect(fulfilled).toBe(false)
 
+          angular.element(document.querySelector('input')).val('+1234').triggerHandler('change')
+          angular.element(document.querySelector('textarea')).val('summary').triggerHandler('change')
           angular.element(document.querySelector('.btn-modal-accept'))
             .triggerHandler('click')
 
@@ -859,8 +859,6 @@ describe('services:', () ->
 
           ModalService.confirm({
             title: 'Foo',
-            initial: 'Bar',
-            initial_urn: '123',
           })
           .catch(-> rejected = true)
 
@@ -872,6 +870,86 @@ describe('services:', () ->
 
           $rootScope.$apply()
           expect(rejected).toBe(true)
+        )
+
+        it('should display an error if there is no urn', () ->
+          fulfilled = false
+
+          $httpBackend.expectGET('/partner/?with_activity=false')
+            .respond([])
+          ModalService.create_case({
+            title: 'Foo',
+          })
+          .then(-> fulfilled = true)
+
+          $rootScope.$apply()
+          expect(fulfilled).toBe(false)
+
+          angular.element(document.querySelector('.btn-modal-accept'))
+            .triggerHandler('click')
+
+          $rootScope.$apply()
+
+          expect(document.querySelector('.has-error label').innerHTML).toContain('Recipient')
+          expect(document.querySelector('.form-group .help-block').innerHTML).toContain('Required')
+          expect(document.querySelector('.form-group .help-block').className).not.toContain('ng-hide')
+          expect(fulfilled).toBe(false)
+        )
+
+        it('should display an error if there is no summary', () ->
+          fulfilled = false
+
+          $httpBackend.expectGET('/partner/?with_activity=false')
+            .respond([])
+          ModalService.create_case({
+            title: 'Foo',
+          })
+          .then(-> fulfilled = true)
+
+          $rootScope.$apply()
+          expect(fulfilled).toBe(false)
+
+          angular.element(document.querySelector('input')).val('+1234').triggerHandler('change')
+          angular.element(document.querySelector('.btn-modal-accept'))
+            .triggerHandler('click')
+
+          $rootScope.$apply()
+
+          expect(document.querySelector('.has-error label').innerHTML).toContain('Summary')
+          expect(document.querySelectorAll('.form-group')[1].querySelector('.help-block').innerHTML)
+              .toContain('Required')
+          expect(document.querySelectorAll('.form-group')[1].querySelector('.help-block').className)
+              .not.toContain('ng-hide')
+          expect(fulfilled).toBe(false)
+        )
+
+        it('should display an error if the summary is too long', () ->
+          fulfilled = false
+
+          $httpBackend.expectGET('/partner/?with_activity=false')
+            .respond([])
+          ModalService.create_case({
+            title: 'Foo',
+            maxLength: 3,
+          })
+          .then(-> fulfilled = true)
+
+          $rootScope.$apply()
+          expect(fulfilled).toBe(false)
+
+          angular.element(document.querySelector('input')).val('+1234').triggerHandler('change')
+          angular.element(document.querySelector('textarea')).val('too long').triggerHandler('change')
+          angular.element(document.querySelector('.btn-modal-accept'))
+            .triggerHandler('click')
+
+          $rootScope.$apply()
+
+          expect(document.querySelector('.has-error label').innerHTML).toContain('Summary')
+          expect(document.querySelectorAll('.form-group')[1].querySelectorAll('.help-block')[1].innerHTML)
+              .toContain('Too long')
+          expect(document.querySelectorAll('.form-group')[1].querySelectorAll('.help-block')[1].className)
+              .not.toContain('ng-hide')
+          expect(fulfilled).toBe(false)
         )
     )
   )

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -209,7 +209,7 @@ controllers.controller('BaseItemsController', ['$scope', 'UtilsService', ($scope
 #============================================================================
 # Incoming messages controller
 #============================================================================
-controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal', '$controller', 'CaseService', 'MessageService', 'PartnerService', 'UserService', 'UtilsService', ($scope, $timeout, $uibModal, $controller, CaseService, MessageService, PartnerService, UserService, UtilsService) ->
+controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal', '$controller', 'CaseService', 'InboxUIService', 'MessageService', 'PartnerService', 'UserService', 'UtilsService', ($scope, $timeout, $uibModal, $controller, CaseService, InboxUIService, MessageService, PartnerService, UserService, UtilsService) ->
   $controller('BaseItemsController', {$scope: $scope})
 
   $scope.advancedSearch = false
@@ -342,6 +342,9 @@ controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal',
       PartnerService.fetchAll().then((partners) ->
         newCaseFromMessage(message, partners)
       )
+
+  $scope.onCaseWithoutMessage = () ->
+      InboxUIService.createCaseWithoutMessage()
 
   $scope.onLabelMessage = (message) ->
     UtilsService.labelModal("Labels", "Update the labels for this message. This determines which other partner organizations can view this message.", $scope.labels, message.labels).then((selectedLabels) ->

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -588,7 +588,6 @@ services.factory('ModalService', ['$rootScope', '$uibModal', ($rootScope, $uibMo
       title = null,
       templateUrl = '/sitestatic/templates/modals/create_case.html',
       initial='',
-      initial_urn='',
       maxLength=255,
       schemes = {tel: "Phone", twitter: "Twitter", email: "Email"},
     } = {}) ->
@@ -599,10 +598,10 @@ services.factory('ModalService', ['$rootScope', '$uibModal', ($rootScope, $uibMo
         }),
         controller: ($scope, $uibModalInstance, PartnerService, UserService) ->
           $scope.fields = {
-            urn: {scheme: null, path: initial_urn},
+            urn: {scheme: null, path: ""},
             text: {val: initial, maxLength: maxLength},
             partner: {val: 0, choices:[]},
-            user: {val: 0, choices: [{name: "Anyone"}]}
+            user: {val: 0, choices: []}
           }
 
 

--- a/static/templates/modals/create_case.html
+++ b/static/templates/modals/create_case.html
@@ -1,0 +1,54 @@
+<div class="modal-header">
+  <h3 class="modal-title">[[ title ]]</h3>
+</div>
+
+<div class="modal-body">
+    <form name="form" novalidate>
+        <div class="form-group" ng-class='{"has-error": form.path.$invalid && (form.path.$dirty || form.submitted)}'>
+            <label class="control-label">
+                Recipient
+            </label>
+            <div class="input-group">
+                <div class="input-group-btn">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                        [[ urn_scheme_label ]]
+                        <span class='caret'></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li> <a ng-click='setScheme("tel")'>Phone</a> </li>
+                        <li> <a ng-click='setScheme("twitter")'>Twitter</a> </li>
+                        <li> <a ng-click='setScheme("email")'>Email</a> </li>
+                    </ul>
+                </div>
+                <input class="form-control" type="text" ng-model="fields.urn.path" name="path" required style="width: 300px">
+            </div>
+            <div class="help-block" ng-show="form.path.$invalid && (form.path.$dirty || form.submitted)">
+                Required
+            </div>
+        </div>
+        <div class="form-group" ng-class='{"has-error": form.text.$invalid}'>
+            <label class="control-label">
+                Summary
+            </label>
+            <textarea class="form-control" ng-model="fields.text.val" ng-maxlength="fields.text.maxLength" name="text" required></textarea>
+            <div class="help-block" ng-show="form.text.$error.required">
+                Required
+            </div>
+            <div class="help-block" ng-show="form.text.$error.maxlength">
+                Too long
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="control-label">
+                Assign to user/partner
+            </label>
+            <select class="form-control" ng-model="fields.partner.val" ng-options="p.name for p in fields.partner.choices track by p.id" ng-change="refreshUserList()"> </select>
+            <select class="form-control" ng-model="fields.user.val" ng-options="u.name for u in fields.user.choices track by u.id"></select>
+        </div>
+    </form>
+</div>
+
+<div class="modal-footer">
+  <button class="btn btn-primary btn-modal-accept" ng-click="ok()">Create</button>
+  <button class="btn btn-default btn-modal-cancel" ng-click="cancel()">Cancel</button>
+</div>

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -24,6 +24,8 @@
         %form.clearfix
           .btn-group.pull-away
             // TODO figure out why form is double-submitted when this is moved to ng-submit on the form. jQuery conflict?
+            %button.btn.btn-default{ type:"button", ng-click:"onCaseWithoutMessage()", ng-if:'folder == "inbox"'}
+              - trans "Create Case"
             %button.btn.btn-default{ type:"button", ng-click:"onSearch()" }
               %i.glyphicon.glyphicon-search
               - trans "Search"


### PR DESCRIPTION
Now that we have done all the backend preparation work for being able to create a case without the `initial_message` field, we can move onto creating the modal (and the button to bring up the modal), which will allow users to create a case, by specifying the URN and description, without needing the initial message.