### PR TITLE
faq wrapping fix

### DIFF
--- a/static/less/cases.less
+++ b/static/less/cases.less
@@ -147,6 +147,15 @@ ul.header-details li {
   list-style: none;
 }
 
+td.value-answer {
+  word-break: break-word;
+}
+td.value-question {
+  min-width: 100px;
+  max-width: 300px;
+  word-wrap: break-word;
+}
+
 .loading {
   background: url('../img/loading.gif') no-repeat center center;
   margin: 12px;


### PR DESCRIPTION
Added some line breaking rules to the FAQ table's Questions and Answers columns

@Mitso Please review

**Before:**
![screen shot 2016-09-20 at 12 41 32 pm](https://cloud.githubusercontent.com/assets/9653693/18667293/426aa778-7f30-11e6-8c1f-d1207e719102.png)

**After:**
![screen shot 2016-09-20 at 12 42 02 pm](https://cloud.githubusercontent.com/assets/9653693/18667301/4f444562-7f30-11e6-9777-8deda093b602.png)
