### PR TITLE
un-flag confirmation prompt added

### DIFF
--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -316,9 +316,16 @@ controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal',
   #----------------------------------------------------------------------------
 
   $scope.onToggleMessageFlag = (message) ->
-    MessageService.bulkFlag([message], !message.flagged).then(() ->
-      $scope.updateItems()
-    )
+    if $scope.folder == 'flagged'
+      UtilsService.confirmModal('Are you sure you want to un-flag this message?').then(() ->
+         MessageService.bulkFlag([message], !message.flagged).then(() ->
+          $scope.updateItems()
+        )
+      )
+    else
+      MessageService.bulkFlag([message], !message.flagged).then(() ->
+        $scope.updateItems()
+      )
 
   $scope.onReplyToMessage = (message) ->
     $uibModal.open({templateUrl: '/partials/modal_reply.html', controller: 'ReplyModalController', resolve: {selection: (() -> null), maxLength: (() -> OUTGOING_TEXT_MAX_LEN)}})


### PR DESCRIPTION
Insert a confirmation prompt/popup before a message is selected to be unflagged 
note: CONFIRMATION SHOULD ONLY BE TRIGGERED WHEN IN THE FLAGGED FILTER VIEW, not in the Inbox.

@Mitso please review

![screen shot 2016-09-22 at 7 56 16 pm](https://cloud.githubusercontent.com/assets/9653693/18778409/67ecd016-8174-11e6-916e-051b7cd07e73.png)