### PR TITLE
Small fixes for python3 support

### DIFF
--- a/casepro/msgs/tasks.py
+++ b/casepro/msgs/tasks.py
@@ -130,9 +130,9 @@ def faq_csv_import(org, task_id):  # pragma: no cover
     task.save()
 
     try:
-        with transaction.atomic():  # prevents partial csv import - all or nothing
+        with transaction.atomic() and open(task.csv_file.path) as csv_file:  # transaction prevents partial csv import
             # Load csv into Dict
-            records = csv.DictReader(task.csv_file)
+            records = csv.DictReader(csv_file)
             lines = 0
 
             for line in records:

--- a/casepro/msgs/tasks.py
+++ b/casepro/msgs/tasks.py
@@ -149,7 +149,7 @@ def faq_csv_import(org, task_id):  # pragma: no cover
 
                 # Start creation of translation FAQs
                 # get a list of the csv keys
-                keys = line.keys()
+                keys = list(line)
                 # remove non-translation keys
                 parent_keys = ['Parent Question', 'Parent Language', 'Parent Answer', 'Parent ID', 'Labels']
                 [keys.remove(parent_key) for parent_key in parent_keys]

--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import calendar
 import iso639
 import json
-import phonenumbers
 import pytz
 import re
 import six
@@ -18,12 +17,6 @@ from uuid import UUID
 
 
 LANGUAGES_BY_CODE = {}  # cache of language lookups
-
-
-class InvalidURN(Exception):
-    """
-    A generic exception thrown when validating URNs and they don't conform to E164 format
-    """
 
 
 def parse_csv(csv, as_ints=False):
@@ -96,29 +89,6 @@ def normalize(text):
     multiple whitespace characters with single spaces.
     """
     return unicodedata.normalize('NFKD', re.sub(r'\s+', ' ', text.lower()))
-
-
-def validate_urn_as_e164(number):
-    try:
-        parsed = phonenumbers.parse(number)
-    except phonenumbers.NumberParseException as e:
-        raise InvalidURN(e.message)
-
-    if number != phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164):
-        raise InvalidURN("Phone numbers must be in E164 format")
-
-    if not phonenumbers.is_possible_number(parsed) or not phonenumbers.is_valid_number(parsed):
-        raise InvalidURN("Phone numbers must be in E164 format")
-
-    return True
-
-
-def validate_urn(urn):
-    scheme, path = urn.split(':', 1)
-    if scheme == 'tel':
-        return validate_urn_as_e164(path)
-
-    return True
 
 
 def match_keywords(text, keywords):

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -16,7 +16,7 @@ from casepro.test import BaseCasesTest
 
 from . import safe_max, normalize, match_keywords, truncate, str_to_bool, json_encode, TimelineItem, uuid_to_int
 from . import date_to_milliseconds, datetime_to_microseconds, microseconds_to_datetime, month_range, date_range
-from . import get_language_name, json_decode, humanise_seconds, validate_urn_as_e164, InvalidURN
+from . import get_language_name, json_decode, humanise_seconds
 from .email import send_email
 from .middleware import JSONMiddleware
 
@@ -160,14 +160,6 @@ class UtilsTest(BaseCasesTest):
         self.assertEqual(humanise_seconds(86501), "1d 1s")
         self.assertEqual(humanise_seconds(86561), "1d 1m 1s")
         self.assertEqual(humanise_seconds(90161), "1d 1h 1m 1s")
-
-    def test_validate_urn_as_e164(self):
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '0825550011')
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '0027825550011')
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '027825550011')
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '0027005550011')
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '0027825550011445566')
-        self.assertTrue(validate_urn_as_e164('+27825552233'))
 
 
 class EmailTest(BaseCasesTest):


### PR DESCRIPTION
There were a few problems with python3 support.
1. DictReader doesn't seem to default to text mode when opening files
2. The keys() method on a dictionary no longer returns a list in python 3 (it returns a view object)
3. When merging the code from upstream I failed to spot some removed code

I've already cherry-picked the first two commits into https://github.com/rapidpro/casepro/pull/117 so that they will land upstream eventually