### PR TITLE
add labels to archive folder

### DIFF
--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -356,7 +356,7 @@ class Message(models.Model):
         all_label_access = user.can_administer(org)
 
         if all_label_access:
-            if folder == MessageFolder.inbox:
+            if folder == MessageFolder.inbox or MessageFolder.archived:
                 queryset = queryset.filter(has_labels=True)
                 if label_id:
                     label = Label.get_all(org, user).filter(pk=label_id).first()

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -356,7 +356,7 @@ class Message(models.Model):
         all_label_access = user.can_administer(org)
 
         if all_label_access:
-            if folder == MessageFolder.inbox or MessageFolder.archived:
+            if folder == MessageFolder.inbox or (folder == MessageFolder.archived and label_id):
                 queryset = queryset.filter(has_labels=True)
                 if label_id:
                     label = Label.get_all(org, user).filter(pk=label_id).first()

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -952,6 +952,10 @@ class MessageTest(BaseCasesTest):
         # archived as admin shows all archived
         assert_search(self.admin, {'folder': MessageFolder.archived}, [msg11, msg10, msg9, msg4])
 
+        # archived with label as admin shows all archived with that label
+        assert_search(self.admin, {'folder': MessageFolder.archived, 'label': self.aids.pk}, [msg11, msg9])
+        assert_search(self.admin, {'folder': MessageFolder.archived, 'label': self.pregnancy.pk}, [msg10])
+
         # unlabelled as admin shows all non-archived unlabelled
         assert_search(self.admin, {'folder': MessageFolder.unlabelled}, [msg3, msg2, msg1])
 
@@ -970,6 +974,10 @@ class MessageTest(BaseCasesTest):
         # archived as user shows all archived with their labels
         assert_search(self.user1, {'folder': MessageFolder.archived}, [msg11, msg10, msg9])
         assert_search(self.user3, {'folder': MessageFolder.archived}, [msg11, msg9])
+
+        # archived with label as user shows all archived with that label.. if user can see that label
+        assert_search(self.user1, {'folder': MessageFolder.archived, 'label': self.pregnancy.pk}, [msg10])
+        assert_search(self.user3, {'folder': MessageFolder.archived, 'label': self.pregnancy.pk}, [])
 
         # unlabelled as user throws exception
         self.assertRaises(ValueError, Message.search, self.unicef, self.user1, {'folder': MessageFolder.unlabelled})

--- a/templates/cases/inbox_base.haml
+++ b/templates/cases/inbox_base.haml
@@ -45,7 +45,8 @@
             %li{ class:"{% if_url 'cases.inbox' 'active' '' %}" }
               %a{ href:"{% url 'cases.inbox' %}" }
                 - trans "Inbox"
-              %ul.label-menu{ ng-if:"labels.length > 0" }
+                  %span.caret.arrow{ ng-show:'folder == "inbox"' }
+              %ul.label-menu{ ng-if:"labels.length > 0", id:'inbox', ng-show:'folder == "inbox"' }
                 %li.label-link{ ng-repeat:"label in labels" }
                   %a{ ng-href:"/#?label=[[ label.name | urlencode ]]", ng-class:'{ strong: label == activeLabel }' }
                     %span.glyphicon.glyphicon-tag{ style:"font-size: 0.75em" }
@@ -56,6 +57,12 @@
             %li{ class:"{% if_url 'cases.archived' 'active' '' %}" }
               %a{ href:"{% url 'cases.archived' %}" }
                 - trans "Archived"
+                  %span.caret.arrow{ ng-show:'folder == "archived"' }
+              %ul.label-menu{ ng-if:"labels.length > 0", ng-show:'folder == "archived"' }
+                %li.label-link{ ng-repeat:"label in labels" }
+                  %a{ ng-href:"{% url 'cases.archived' %}#?label=[[ label.name | urlencode ]]", ng-class:'{ strong: label == activeLabel }' }
+                    %span.glyphicon.glyphicon-tag{ style:"font-size: 0.75em" }
+                    [[ label.name | deunderscore ]] ([[ label.counts.archived ]])
             - if perms.msgs.message_unlabelled or org_perms.msgs.message_unlabelled
               %li{ class:"{% if_url 'cases.unlabelled' 'active' '' %}" }
                 %a{ href:"{% url 'cases.unlabelled' %}" }


### PR DESCRIPTION
*Requirements*
- Helpdesk staff would also like to see the label ‘population’ of the archive, similar to Inbox. 
- Suggestion: Show labels (such as Compliment, Complaint, Opt Out, etc) underneath Archive as well in order to show how many messages have been responded to within each label. 
- They would also like to click on a label under Archive in order to view all ‘Compliments’ that have been archived, for example.
- the labels under Inbox and Archive should be collapsable
