### PR TITLE
Fix error on long language field imports

### DIFF
--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -175,6 +175,7 @@ class IdentityStoreContact(object):
         remote_language = json_data.get('details').get(language_field)
         if remote_language is not None:
             self.language, _, _ = remote_language.partition('_')
+            self.language = self.language[:3]
         self.name = json_data.get('details').get('name', None)
         self.fields = {}
         self.groups = {}

--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -154,9 +154,11 @@ class IdentityStore(object):
         identities = self.get_paginated_response(url, pages=True, params=params)
 
         # Users who opt to be forgotten from the system have their details
-        # stored as 'redacted'.
+        # stored as 'redacted'. Language field is a good field to check, since
+        # every user that we send messages to has to have a language set.
+        language_field = getattr(settings, 'IDENTITY_LANGUAGE_FIELD', "language")
         for page in identities:
-            yield [IdentityStoreContact(i) for i in page if i.get('details').get('name') != "redacted"]
+            yield [IdentityStoreContact(i) for i in page if i.get('details').get(language_field) != "redacted"]
 
 
 class IdentityStoreContact(object):

--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -159,7 +159,6 @@ class JunebugBackendTest(BaseCasesTest):
                     'id': "test_id",
                     'version': 1,
                     'details': {
-                        'name': "redacted",
                         'addresses': {},
                         'language': "redacted",
                     },

--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -173,6 +173,31 @@ class JunebugBackendTest(BaseCasesTest):
         }
         return (201, headers, json.dumps(resp))
 
+    def identity_store_long_language_callback(self, request):
+        headers = {'Content-Type': "application/json"}
+        resp = {
+            'count': 1,
+            'next': None,
+            'previous': None,
+            'results': [
+                {
+                    'id': "test_id",
+                    'version': 1,
+                    'details': {
+                        'addresses': {},
+                        'language': "english_ZA",
+                    },
+                    'communicate_through': None,
+                    'operator': None,
+                    'created_at': "2016-02-14T10:21:00.258406Z",
+                    'created_by': 1,
+                    'updated_at': "2016-03-14T10:21:00.258406Z",
+                    'updated_by': 1
+                }
+            ]
+        }
+        return (201, headers, json.dumps(resp))
+
     @responses.activate
     def test_pull_contacts_recently_created(self):
         self.add_identity_store_callback(
@@ -269,6 +294,30 @@ class JunebugBackendTest(BaseCasesTest):
         [contact] = Contact.objects.all()
         self.assertEqual(contact.uuid, "test_id")
         self.assertEqual(contact.name, "test")
+
+    @responses.activate
+    def test_pull_contacts_long_language_code(self):
+        """
+        If a contact is pulled that has a language code longer than 3 characters, it should be truncated.
+        """
+        self.add_identity_store_callback(
+            "created_to=2016-03-14T10%3A21%3A00&created_from=2016-03-14T10%3A25%3A00",
+            self.identity_store_long_language_callback
+        )
+        self.add_identity_store_callback(
+            "updated_to=2016-03-14T10%3A21%3A00&updated_from=2016-03-14T10%3A25%3A00",
+            self.identity_store_no_matches_callback
+        )
+
+        (created, updated, deleted, ignored) = self.backend.pull_contacts(
+            self.unicef, "2016-03-14T10:25:00", "2016-03-14T10:21:00")
+        self.assertEqual(created, 1)
+        self.assertEqual(updated, 0)
+        self.assertEqual(deleted, 0)
+        self.assertEqual(ignored, 0)
+        self.assertEqual(Contact.objects.count(), 1)
+        [contact] = Contact.objects.all()
+        self.assertEqual(contact.language, 'eng')
 
     def test_pull_fields(self):
         """


### PR DESCRIPTION
Currently, if the language field is longer than 3 characters, the sync fails. This is due to the language field having a character limit of 3 in the database. If the language field is longer than this, then we should truncate the field before storing it on the contact.