### PR TITLE
Stop installing nginx in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM praekeltfoundation/django-bootstrap:onbuild
 RUN apt-get-install.sh git libjpeg-dev zlib1g-dev libtiff-dev nodejs npm \
-    nginx redis-server supervisor libpq-dev gcc && \
+    redis-server supervisor libpq-dev gcc && \
     ln -s /usr/bin/nodejs /usr/bin/node
 
 ENV DJANGO_SETTINGS_MODULE "casepro.settings_production"


### PR DESCRIPTION
@JayH5 pointed out that the upstream django-bootstrap container already has nginx installed.

I'm pretty sure we could stop using the specific django.conf in this repo and just use the upstream one. But not sure enough to make that change yet.