### PR TITLE
Remove cell number and language from pod

### DIFF
--- a/casepro/settings_production_momza.py
+++ b/casepro/settings_production_momza.py
@@ -10,8 +10,6 @@ PODS[0]['contact_id_fieldname'] = os.environ.get(  # noqa: F405
 )
 
 PODS[0]['field_mapping'] = [  # noqa: F405
-    {"field": "msisdn_registrant", "field_name": "Cell Number"},
-    {"field": "language", "field_name": "Language Preference"},
     {"field": "faccode", "field_name": "Facility Code"},
     {"field": "reg_type", "field_name": "Registration Type"},
     {"field": "mom_dob", "field_name": "Mother's Date of Birth"},


### PR DESCRIPTION
We started using the identity store and the hub to fetch this information, but unfortunately the field names are different depending on which service the info is coming from.

These 2 fields are already displayed in the CasePro interface so it makes sense to not use the pod at all for them.