### PR TITLE
Default channel id to empty string

### DIFF
--- a/casepro/backend/junebug.py
+++ b/casepro/backend/junebug.py
@@ -46,12 +46,12 @@ class HubMessageSender(object):
             reply_to = ''
             label = ''
             inbound_created_on = outgoing.created_on
-            inbound_channel_id = None
+            inbound_channel_id = ""
         else:
             reply_to = outgoing.reply_to.text
             label = ','.join([str(l) for l in outgoing.reply_to.labels.all()])
             inbound_created_on = outgoing.reply_to.created_on
-            inbound_channel_id = outgoing.reply_to.metadata.get('channel_id', None)
+            inbound_channel_id = outgoing.reply_to.metadata.get('channel_id', "")
 
         return {
             'to': to_addr,

--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -690,7 +690,7 @@ class JunebugBackendTest(BaseCasesTest):
                 'content': "That's great", 'inbound_created_on': '2016-11-17T10:30:00+00:00',
                 'outbound_created_on': '2016-11-17T10:30:00+00:00',
                 'label': '', 'reply_to': '', 'to': '+1234', 'user_id': 'C-002', 'helpdesk_operator_id': self.user1.id,
-                'inbound_channel_id': None})
+                'inbound_channel_id': ''})
             headers = {'Content-Type': "application/json"}
             resp = {
                 'status': 201,


### PR DESCRIPTION
Use a blank string rather than `None` as the default value for the channel_id string (this is as per DRF recommendations)