### PR TITLE
Update Junebug urls for routing

### DIFF
--- a/casepro/backend/tests/test_junebug.py
+++ b/casepro/backend/tests/test_junebug.py
@@ -563,7 +563,7 @@ class JunebugBackendTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://localhost:8080/',
+                'API_URL': 'http://localhost:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         })
@@ -599,7 +599,7 @@ class JunebugBackendTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://localhost:8080/',
+                'API_URL': 'http://localhost:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         },
@@ -663,7 +663,7 @@ class JunebugBackendTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://localhost:8080/',
+                'API_URL': 'http://localhost:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         },
@@ -724,7 +724,7 @@ class JunebugBackendTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://localhost:8080/',
+                'API_URL': 'http://localhost:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         },
@@ -1233,7 +1233,7 @@ class JunebugInboundViewTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://localhost:8080/',
+                'API_URL': 'http://localhost:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         })
@@ -1262,11 +1262,11 @@ class JunebugInboundViewTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://bad.example.org:8080/',
+                'API_URL': 'http://bad.example.org:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             },
             'junebug-channel-id': {
-                'API_ROOT': 'http://good.example.org:8080/',
+                'API_URL': 'http://good.example.org:8080/channels/junebug-channel-id/messages/',
                 'FROM_ADDRESS': '+6789',
             }
         })
@@ -1319,7 +1319,7 @@ class JunebugInboundViewTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://username:password@auth.example.org:8080/',
+                'API_URL': 'http://username:password@auth.example.org:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             },
         })
@@ -1348,7 +1348,7 @@ class JunebugInboundViewTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://default.example.org:8080/',
+                'API_URL': 'http://default.example.org:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         })
@@ -1401,7 +1401,7 @@ class JunebugInboundViewTest(BaseCasesTest):
         JUNEBUG_DEFAULT_CHANNEL_ID='replace-me',
         JUNEBUG_CHANNELS={
             'replace-me': {
-                'API_ROOT': 'http://default.example.org:8080/',
+                'API_URL': 'http://default.example.org:8080/channels/replace-me/messages/',
                 'FROM_ADDRESS': '+4321',
             }
         })

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -62,7 +62,7 @@ SITE_MAX_MESSAGE_CHARS = 160  # the max value for this is 800
 JUNEBUG_DEFAULT_CHANNEL_ID = 'replace-me'
 JUNEBUG_CHANNELS = {
     JUNEBUG_DEFAULT_CHANNEL_ID: {
-        'API_ROOT': 'http://localhost:8080/',
+        'API_URL': 'http://localhost:8080/channels/replace-me/messages/',
         'FROM_ADDRESS': None,
     }
 }

--- a/casepro/settings_production.py
+++ b/casepro/settings_production.py
@@ -38,7 +38,7 @@ EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD', '')
 # junebug configuration
 def parse_channel_info(data):
     """
-    Expected format: `<channel_id>,<from_addr>,<api_root>;<channel_id>,<from_addr>,<api_root>;`
+    Expected format: `<channel_id>,<from_addr>,<api_url>;<channel_id>,<from_addr>,<api_url>;`
 
     Returns a tuple.
     The first item is the assumed default junebug channel which can be used as a
@@ -50,12 +50,12 @@ def parse_channel_info(data):
     channels = {}
     default_channel_id = None
     for channel in data.strip().split(';'):
-        channel_id, from_addr, api_root = channel.split(',')
+        channel_id, from_addr, api_url = channel.split(',')
         if not default_channel_id:
             default_channel_id = channel_id.strip()
         channels[channel_id.strip()] = {
             'FROM_ADDRESS': from_addr.strip(),
-            'API_ROOT': api_root.strip(),
+            'API_URL': api_url.strip(),
         }
     return default_channel_id, channels
 
@@ -72,7 +72,7 @@ else:
     JUNEBUG_CHANNELS = {
         JUNEBUG_DEFAULT_CHANNEL_ID: {
             'FROM_ADDRESS': os.environ.get('JUNEBUG_FROM_ADDRESS', None),
-            'API_ROOT': os.environ.get('JUNEBUG_API_ROOT', 'http://localhost:8080/'),
+            'API_URL': os.environ.get('JUNEBUG_API_URL', 'http://localhost:8080/channels/replace-me/messages/'),
         }
     }
 

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -44,7 +44,7 @@ phonenumbers==8.0.0       # via rapidpro-dash
 pillow==3.4.2
 pisa==3.0.33
 polib==1.0.8              # via django-rosetta
-psycopg2==2.6.2
+psycopg2==2.7.1
 pycodestyle==2.2.0        # via flake8
 pycountry==16.11.27.1
 pyflakes==1.3.0           # via flake8


### PR DESCRIPTION
This change will allow us to configure Casepro to use a router based channel, the url is not `/channels/<channel-id>/messages/` but something like `/routers/<router-id>/destinations/<destination-id>/messages/`.

Currently the url is built in the code, this PR allows us to rather specify it completely.
